### PR TITLE
[DET-3184] Add a det-nobody user.

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -84,6 +84,14 @@ RUN ${CONDA_DIR}/bin/python3.6 -m pip uninstall -y determined determined-cli det
 
 COPY files/additional-requirements.txt files/additional-requirements.txt
 RUN ${CONDA_DIR}/bin/python3.6 -m pip install -r files/additional-requirements.txt
+
 COPY files/notebook-requirements.txt files/notebook-requirements.txt
 RUN ${CONDA_DIR}/bin/python3.6 -m pip install -r files/notebook-requirements.txt
 ENV JUPYTER_CONFIG_DIR=/run/determined/jupyter/config JUPYTER_DATA_DIR=/run/determined/jupyter/data JUPYTER_RUNTIME_DIR=/run/determined/jupyter/runtime
+
+# Add a det-nobody user. Unlike the traditional nobody user, det-nobody will
+# have a HOME directory that exists in order to support tools which require a
+# home directory, like gsutil. det-nobody is designed to be an out-of-the-box
+# solution for running workloads in unprivileged containers.
+RUN groupadd --gid 65533 det-nobody \
+  && useradd --create-home --home-dir /tmp/det-nobody --uid 65533 --gid 65533 --shell /bin/bash det-nobody

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -109,3 +109,10 @@ RUN ${CONDA_DIR}/bin/python3.6 -m pip install -r files/additional-requirements.t
 COPY files/notebook-requirements.txt files/notebook-requirements.txt
 RUN ${CONDA_DIR}/bin/python3.6 -m pip install -r files/notebook-requirements.txt
 ENV JUPYTER_CONFIG_DIR=/run/determined/jupyter/config JUPYTER_DATA_DIR=/run/determined/jupyter/data JUPYTER_RUNTIME_DIR=/run/determined/jupyter/runtime
+
+# Add a det-nobody user. Unlike the traditional nobody user, det-nobody will
+# have a HOME directory that exists in order to support tools which require a
+# home directory, like gsutil. det-nobody is designed to be an out-of-the-box
+# solution for running workloads in unprivileged containers.
+RUN groupadd --gid 65533 det-nobody \
+  && useradd --create-home --home-dir /tmp/det-nobody --uid 65533 --gid 65533 --shell /bin/bash det-nobody


### PR DESCRIPTION
An alternate strategy I considered was using non-unique-uid users (the `--non-unique` option of `useradd`) to add an alias user to `nobody` with the same UID as the `nobody` user, but then when launching docker containers, to specify the user by name instead of by UID.  This is apparently a behavior that exists in Linux but from what I can tell it is discouraged as being non-standard and kinda fragile.

We could also have just set the `nobody` user's `HOME` to a real directory, but IMO it is best to leave the `nobody` user in its default state.

Users wanting to have the same features in custom images will have to duplicate these lines from our Dockerfiles, which is why I left comments explaining the situations where they are useful.