### PR TITLE
Introduce libnss_determined.

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -95,3 +95,11 @@ ENV JUPYTER_CONFIG_DIR=/run/determined/jupyter/config JUPYTER_DATA_DIR=/run/dete
 # solution for running workloads in unprivileged containers.
 RUN groupadd --gid 65533 det-nobody \
   && useradd --create-home --home-dir /tmp/det-nobody --uid 65533 --gid 65533 --shell /bin/bash det-nobody
+
+# Add a plugin to the user system that lets us extend the users available in
+# the container at runtime. This is critical for supporting non-root shell,
+# which in turn is critical for non-root distributed training.
+COPY libnss_determined /tmp/libnss_determined
+RUN make -C /tmp/libnss_determined libnss_determined.so.2 install \
+  && rm -rf /tmp/libnss_determined \
+  && sed -E -i -e 's/^((passwd|shadow|group):.*)/\1 determined/' /etc/nsswitch.conf

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -116,3 +116,11 @@ ENV JUPYTER_CONFIG_DIR=/run/determined/jupyter/config JUPYTER_DATA_DIR=/run/dete
 # solution for running workloads in unprivileged containers.
 RUN groupadd --gid 65533 det-nobody \
   && useradd --create-home --home-dir /tmp/det-nobody --uid 65533 --gid 65533 --shell /bin/bash det-nobody
+
+# Add a plugin to the user system that lets us extend the users available in
+# the container at runtime. This is critical for supporting non-root shell,
+# which in turn is critical for non-root distributed training.
+COPY libnss_determined /tmp/libnss_determined
+RUN make -C /tmp/libnss_determined libnss_determined.so.2 install \
+  && rm -rf /tmp/libnss_determined \
+  && sed -E -i -e 's/^((passwd|shadow|group):.*)/\1 determined/' /etc/nsswitch.conf

--- a/libnss_determined/.clang-format
+++ b/libnss_determined/.clang-format
@@ -1,0 +1,3 @@
+---
+BasedOnStyle:  Google
+IndentWidth:     4

--- a/libnss_determined/.gitignore
+++ b/libnss_determined/.gitignore
@@ -1,0 +1,2 @@
+test/unit_test
+libnss_determined.so.2

--- a/libnss_determined/Dockerfile
+++ b/libnss_determined/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        valgrind \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY . /tmp/libnss_determined
+
+RUN make -C /tmp/libnss_determined libnss_determined.so.2 install \
+  && rm -rf /tmp/libnss_determined \
+  && sed -E -i -e 's/^((passwd|shadow|group):.*)/\1 determined/' /etc/nsswitch.conf \
+  && mkdir -p /run/determined/etc \
+  && echo "user:x:1000:1000::/home/user:/bin/bash" > /run/determined/etc/passwd \
+  && echo "user:THEHASH:18459::::::" > /run/determined/etc/shadow \
+  && echo "user:x:1000:" > /run/determined/etc/group

--- a/libnss_determined/Makefile
+++ b/libnss_determined/Makefile
@@ -1,0 +1,28 @@
+INPUTS := src/parse.c src/util.c src/passwd.c src/shadow.c src/group.c
+OUTPUT := libnss_determined.so.2
+
+CC := gcc
+CFLAGS := -Wall -Wextra -Wswitch-enum -Wsign-conversion -Wformat -Werror
+
+all: $(OUTPUT)
+
+install:
+	cp $(OUTPUT) /lib
+
+$(OUTPUT): Makefile src/libnss_determined.h $(INPUTS)
+	$(CC) $(INPUTS) -o $@ $(CFLAGS) -fPIC -shared -Wl,-soname,$@
+
+test/unit_test: Makefile src/libnss_determined.h $(INPUTS) test/unit_test.c
+	$(CC) $(INPUTS) test/unit_test.c -o $@ $(CFLAGS) -I./src -g
+
+.PHONY: test
+test: test/unit_test
+	test/unit_test
+	test/integration_test.sh
+
+.PHONY: fmt
+fmt:
+	clang-format -i src/*.c src/*.h test/*.c
+
+clean:
+	rm -f $(OUTPUT) test/unit_test

--- a/libnss_determined/README.md
+++ b/libnss_determined/README.md
@@ -1,0 +1,66 @@
+# libnss\_determined
+
+A plugin to the name switch service part of glibc.  This plugin is meant to be
+built/installed in a Docker container during the build process.
+
+See the [glibc documentation](https://gnu.org/software/libc/manual/html_node/NSS-Module-Function-Internals.html).
+
+## How Determined Uses the Plugin
+
+We can't edit a Docker container's `/etc/passwd`, `/etc/shadow`, or
+`/etc/group` at runtime, but we can install this plugin at runtime as a file
+overlay.  Conceptually, this plugin lets us embed files at runtime (like
+`/run/determined/etc/passwd`) to safely and non-invasively extend the real
+`/etc/passwd` in the Docker container.
+
+The reason that we would need to inject users into a container is to make
+programs that query the container's list of users (notably `sshd`) behave
+nicely when running non-root containers.  This is a requisite for non-root
+distributed training and non-root shells to work.
+
+If a custom image does not contain our plugin, but the owner of the custom
+image still wants to use non-root containers, the owner of the custom image is
+responsible for embedding users in the image either at build time (by
+prebuilding users into a container) or at runtime (by bind-mounting sockets to
+connect to an AD user system into the container, for instance).
+
+## Including the Plugin In a Custom Image
+
+The easiest way to include the plugin is to copy the entire `libnss_determined`
+directory to your `docker build` directory and include the relevant lines
+directly from Determined's `Dockerfile.gpu`, for example.
+
+### Manually Building the Plugin
+
+Run `make libnss_determined.so.2`.
+
+### Manually Installing the Plugin
+
+Run `make install`, which will copy `libnss_determined.so.2` to `/lib`.
+
+### Enabling The Plugin
+
+Enable the plugin by appending a `determined` entry to each of the `passwd`,
+`shadow`, and `group` lines of  `/etc/nsswitch.conf`.  See `man nsswitch.conf`
+for details.  This will tell to glibc to call into our plugin whenever it
+queries the `passwd`, `shadow`, or `group` databases.
+
+You can verify that it is working by running `getent passwd`, `getent shadow`,
+and `getent group`.
+
+### Troubleshooting
+
+Enable debug output by setting the `LIBNSS_DETERMINED_DEBUG` environment
+variable to `1` when running programs that will query the plugin:
+
+```
+LIBNSS_DETERMINED_DEBUG=1 getent passwd
+```
+
+### Manually Testing the Plugin
+
+Run `make test`.
+
+Testing includes making calls to `docker build` and `docker run`, so it likely
+won't work from within a container, unless you have configured
+Docker-in-Docker.

--- a/libnss_determined/src/group.c
+++ b/libnss_determined/src/group.c
@@ -1,0 +1,89 @@
+#include "libnss_determined.h"
+
+/*
+group database functions for listing groups:
+
+    These are called to list groups in the database:
+        _nss_determined_setgrent
+        _nss_determined_getgrent_r
+        _nss_determined_endgrent
+
+    This is called to look up a group by name:
+        _nss_determined_getgrnam_r
+
+    This is called to look up a group by uid:
+        _nss_determined_getgrgid_r
+*/
+
+FILE *g_group_f = NULL;
+
+static void clear_group_result(void *result_any, char *buf, size_t buflen) {
+    struct group *result = result_any;
+    *result = (struct group){0};
+    memset(buf, 0, buflen);
+}
+
+static db_iface_t group_db = {
+    .parse_line = parse_group_line,
+    .clear_result = clear_group_result,
+};
+
+enum nss_status _nss_determined_setgrent(int stayopen) {
+    DEBUG("called, stayopen=%d", stayopen);
+
+    det_nss_status_t det_nss_status = det_fopen(GROUPFILE, &g_group_f);
+
+    return set_errnop_and_return_nss_status(det_nss_status, &errno);
+}
+
+enum nss_status _nss_determined_getgrent_r(struct group *result, char *buf,
+                                           size_t buflen, int *errnop) {
+    DEBUG("called");
+
+    det_nss_status_t det_nss_status = getent_any(
+        GROUPFILE, &g_group_f, &group_db, (void *)result, buf, buflen);
+
+    return set_errnop_and_return_nss_status(det_nss_status, errnop);
+}
+
+enum nss_status _nss_determined_endgrent(void) {
+    DEBUG("called");
+    if (g_group_f) fclose(g_group_f);
+    return NSS_STATUS_SUCCESS;
+}
+
+bool group_match_name(void *id, void *result_any) {
+    char *name = id;
+    struct group *result = result_any;
+    return strcmp(name, result->gr_name) == 0;
+}
+
+enum nss_status _nss_determined_getgrnam_r(const char *name,
+                                           struct group *result, char *buf,
+                                           size_t buflen, int *errnop) {
+    DEBUG("called, name=%s", name);
+
+    det_nss_status_t det_nss_status =
+        searchent_any(GROUPFILE, &group_db, group_match_name, (void *)name,
+                      (void *)result, buf, buflen);
+
+    return set_errnop_and_return_nss_status(det_nss_status, errnop);
+}
+
+bool group_match_gid(void *id, void *result_any) {
+    unsigned int *gid = id;
+    struct group *result = result_any;
+    return *gid == result->gr_gid;
+}
+
+enum nss_status _nss_determined_getgrgid_r(gid_t gid, struct group *result,
+                                           char *buf, size_t buflen,
+                                           int *errnop) {
+    DEBUG("called, gid=%u", gid);
+
+    det_nss_status_t det_nss_status =
+        searchent_any(GROUPFILE, &group_db, group_match_gid, (void *)&gid,
+                      (void *)result, buf, buflen);
+
+    return set_errnop_and_return_nss_status(det_nss_status, errnop);
+}

--- a/libnss_determined/src/libnss_determined.h
+++ b/libnss_determined/src/libnss_determined.h
@@ -1,0 +1,157 @@
+#ifndef LIBNSS_DETERMINED_H
+#define LIBNSS_DETERMINED_H
+
+#include <errno.h>
+#include <grp.h>
+#include <limits.h>
+#include <nss.h>
+#include <pwd.h>
+#include <shadow.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef PASSWDFILE
+#define PASSWDFILE "/run/determined/etc/passwd"
+#endif
+
+#ifndef SHADOWFILE
+#define SHADOWFILE "/run/determined/etc/shadow"
+#endif
+
+#ifndef GROUPFILE
+#define GROUPFILE "/run/determined/etc/group"
+#endif
+
+// We only debug if LIBNSS_DETERMINED_DEBUG is true.
+extern bool debug_mode;
+extern bool debug_mode_checked;
+
+/* DEBUG is like fprintf(stderr, ...), except each line is preceeded with the
+   function name and line number of where it was called. */
+#define DEBUG(msg, ...)                                                       \
+    do {                                                                      \
+        if (!debug_mode_checked) {                                            \
+            debug_mode = (getenv("LIBNSS_DETERMINED_DEBUG") != NULL);         \
+            debug_mode_checked = true;                                        \
+        }                                                                     \
+        if (debug_mode) {                                                     \
+            fprintf(stderr, "libnss_determined:%s():%d: " msg "\n", __func__, \
+                    __LINE__, ##__VA_ARGS__);                                 \
+        }                                                                     \
+    } while (0)
+
+/* Custom parsing code is only necessary to be immune to LC_* issues, otherwise
+   we would just call libc functions for fgetpwent, fgetspent, and fgetgrent */
+
+typedef enum {
+    PARSE_OK = 0,
+    PARSE_SHORT_BUFFER,
+    PARSE_EOF,
+    PARSE_INVALID,
+    PARSE_FAIL,
+} parse_status_t;
+
+parse_status_t read_line(FILE *f, char *buf, size_t buflen, size_t *linelen);
+parse_status_t get_field(char *field, char sep, char **nextfield);
+parse_status_t read_uint(char *field, unsigned int *uint);
+parse_status_t read_long(char *field, long int *result);
+parse_status_t read_ulong(char *field, unsigned long int *result);
+
+/* A parse_line_fn takes a line of known linelen, backed by a buffer of buflen,
+   and fills in the appropriate struct (such as a struct passwd) by parsing the
+   line. */
+typedef parse_status_t (*parse_line_fn)(char *line, size_t linelen,
+                                        size_t buflen, void *result_any);
+
+parse_status_t parse_pwd_line(char *line, size_t linelen, size_t buflen,
+                              void *result_any);
+
+parse_status_t parse_shadow_line(char *line, size_t linelen, size_t buflen,
+                                 void *result_any);
+
+parse_status_t parse_group_line(char *line, size_t linelen, size_t buflen,
+                                void *result_any);
+
+/* fgetent_any behaves like fgetpwent, fgetgrent, or fgetspent for reading the
+   next valid line found in a FILE*, only it is more resilient to misconfigured
+   LC_* environment variables. */
+parse_status_t fgetent_any(FILE *f, parse_line_fn parse_line, void *result_any,
+                           char *buf, size_t buflen);
+
+/* Table of return values and *errnop settings for NSS plugin calls:
+   (https://gnu.org/software/libc/manual/html_node/NSS-Modules-Interface.html)
+
+    return val              errno       meaning
+-------------------------------------------------------------------------------
+
+    NSS_STATUS_OK           SUCCESS     The operation was successful.
+
+    NSS_STATUS_TRYAGAIN     ERANGE      The provided buffer is not large
+                                        enough.  The function should be called
+                                        again with a larger buffer.
+
+    NSS_STATUS_UNAVAIL      ENOENT      A necessary input file cannot be found.
+
+    NSS_STATUS_NOTFOUND     SUCCESS     There are no entries. Use this to avoid
+                                        returning errors for inactive services
+                                        which may be enabled at a later time.
+                                        This is not the same as the service
+                                        being temporarily unavailable. This is
+                                        also how you indicate in get*ent_r that
+                                        there are no more entries to list.
+
+    NSS_STATUS_NOTFOUND     ENOENT      The requested entry is not available.
+
+    NSS_STATUS_TRYAGAIN     EAGAIN      One of the functions used ran
+                                        temporarily out of resources or a
+                                        service is currently not available.
+
+   This is pretty confusing, so we abstract it away by returning
+   det_nss_staus_t and translating it to an (errno, nss_status) pair as part
+   of the set_errnop_and_return_nss_status() call.
+*/
+
+typedef enum {
+    DET_NSS_STATUS_OK = 0,
+    // The provided buffer is not long enough.
+    DET_NSS_STATUS_SHORT_BUFFER,
+    // The plugin can't find a necessary input value.
+    DET_NSS_STATUS_MISSING_FILE,
+    // There are no more entries to list in the database.
+    DET_NSS_STATUS_END_OF_ENTRIES,
+    // The requested entry is not in the database (after e.g. a name lookup).
+    DET_NSS_STATUS_ENTRY_NOT_FOUND,
+    // Any other failure.
+    DET_NSS_STATUS_FAIL,
+} det_nss_status_t;
+
+enum nss_status set_errnop_and_return_nss_status(
+    det_nss_status_t det_nss_status, int *errnop);
+
+// det_fopen wraps fopen with return values that are specific to NSS plugins.
+det_nss_status_t det_fopen(char *filename, FILE **f);
+
+/* db_iface_t is a collection of function pointers that define the behavior
+   of a specific database, such as the passwd, shadow, or group databases. */
+typedef struct {
+    parse_line_fn parse_line;
+    void (*clear_result)(void *result_any, char *buf, size_t buflen);
+} db_iface_t;
+
+/* getent_any is the engine behind getpwent, getspent, and getgrent to iterate
+   through each database. */
+det_nss_status_t getent_any(char *filename, FILE **f, db_iface_t *db_iface,
+                            void *result_any, char *buf, size_t buflen);
+
+// A match_fn checks if an entry matches the identifer the caller requested.
+typedef bool (*match_fn)(void *id, void *result_any);
+
+/* searchent_any is the engine behind getpwnam, getpwuid, getspnam, getgrnam,
+   and getgrgid for looking up particular entries in each database */
+det_nss_status_t searchent_any(char *filename, db_iface_t *db_iface,
+                               match_fn match, void *id, void *result_any,
+                               char *buf, size_t buflen);
+
+#endif  // LIBNSS_DETERMINED_H

--- a/libnss_determined/src/parse.c
+++ b/libnss_determined/src/parse.c
@@ -1,0 +1,334 @@
+#include "libnss_determined.h"
+
+// Read a line from a FILE*.
+parse_status_t read_line(FILE *f, char *buf, size_t buflen, size_t *linelen) {
+    if (!fgets(buf, (int)buflen, f)) {
+        // End of file?
+        if (feof(f)) {
+            return PARSE_EOF;
+        }
+        // Unknown failure.
+        return PARSE_FAIL;
+    }
+
+    *linelen = strnlen(buf, buflen);
+
+    // Did we get a well-formed line?
+    if (buf[*linelen - 1] != '\n') {
+        // Discard any incomplete lines at the end of the file.
+        if (*linelen != buflen - 1) {
+            return PARSE_EOF;
+        }
+        return PARSE_SHORT_BUFFER;
+    }
+
+    return PARSE_OK;
+}
+
+// Read a field, replace the separator with a '\0' to make it a c-string.
+parse_status_t get_field(char *field, char sep, char **nextfield) {
+    char *end = strchr(field, sep);
+    if (!end) {
+        return PARSE_INVALID;
+    }
+    *end = '\0';
+    *nextfield = end + 1;
+    return PARSE_OK;
+}
+
+parse_status_t read_uint(char *field, unsigned int *uint) {
+    size_t fieldlen = strlen(field);
+    for (size_t i = 0; i < fieldlen; i++) {
+        if (field[i] < '0' || field[i] > '9') {
+            return PARSE_INVALID;
+        }
+    }
+    char *endptr;
+    int base = 10;
+    errno = 0;
+    long int result = strtol(field, &endptr, base);
+    // Check for conversion errors.
+    if (errno) {
+        return PARSE_INVALID;
+    }
+    // Check for extra characters (pointer comparison).
+    if (endptr != field + fieldlen) {
+        return PARSE_INVALID;
+    }
+    // Check for valid range.
+    if (result > UINT_MAX || result < 0) {
+        return PARSE_INVALID;
+    }
+    *uint = (unsigned int)result;
+    return PARSE_OK;
+}
+
+parse_status_t read_long(char *field, long int *result) {
+    size_t fieldlen = strlen(field);
+    // For shadow.h: treat empty fields specially.
+    if (fieldlen == 0) {
+        *result = -1;
+        return PARSE_OK;
+    }
+    // Only allow 0-9 or '-'.
+    for (size_t i = 0; i < fieldlen; i++) {
+        if (field[i] != '-' && (field[i] < '0' || field[i] > '9')) {
+            return PARSE_INVALID;
+        }
+    }
+    char *endptr;
+    int base = 10;
+    errno = 0;
+    *result = strtol(field, &endptr, base);
+    // Check for conversion errors.
+    if (errno) {
+        return PARSE_INVALID;
+    }
+    // Check for extra characters (pointer comparison).
+    if (endptr != field + fieldlen) {
+        return PARSE_INVALID;
+    }
+    return PARSE_OK;
+}
+
+parse_status_t read_ulong(char *field, unsigned long int *result) {
+    size_t fieldlen = strlen(field);
+    // For shadow.h: treat empty fields specially.
+    if (fieldlen == 0) {
+        *result = (unsigned long int)-1;
+        return PARSE_OK;
+    }
+    // Only allow 0-9.
+    for (size_t i = 0; i < fieldlen; i++) {
+        if (field[i] < '0' || field[i] > '9') {
+            return PARSE_INVALID;
+        }
+    }
+    char *endptr;
+    int base = 10;
+    errno = 0;
+    *result = strtoul(field, &endptr, base);
+    // Check for conversion errors.
+    if (errno) {
+        return PARSE_INVALID;
+    }
+    // Check for extra characters (pointer comparison).
+    if (endptr != field + fieldlen) {
+        return PARSE_INVALID;
+    }
+    return PARSE_OK;
+}
+
+#define READ_STR(sep, output)                  \
+    do {                                       \
+        status = get_field(field, sep, &next); \
+        if (status) return status;             \
+        output = field;                        \
+        field = next;                          \
+    } while (0)
+
+#define READ_UINT(sep, output)                 \
+    do {                                       \
+        status = get_field(field, sep, &next); \
+        if (status) return status;             \
+        status = read_uint(field, output);     \
+        if (status) return status;             \
+        field = next;                          \
+    } while (0)
+
+#define READ_LONG(sep, output)                 \
+    do {                                       \
+        status = get_field(field, sep, &next); \
+        if (status) return status;             \
+        status = read_long(field, output);     \
+        if (status) return status;             \
+        field = next;                          \
+    } while (0)
+
+#define READ_ULONG(sep, output)                \
+    do {                                       \
+        status = get_field(field, sep, &next); \
+        if (status) return status;             \
+        status = read_ulong(field, output);    \
+        if (status) return status;             \
+        field = next;                          \
+    } while (0)
+
+#define ASSERT_FINAL_FIELD(sep)                            \
+    do {                                                   \
+        status = get_field(field, ':', &next);             \
+        if (status != PARSE_INVALID) return PARSE_INVALID; \
+    } while (0)
+
+parse_status_t parse_pwd_line(char *line, size_t linelen, size_t buflen,
+                              void *result_any) {
+    struct passwd *result = result_any;
+    (void)linelen;
+    (void)buflen;
+
+    /* field list of struct passwd (from pwd.h)
+        char *pw_name;   // Username
+        char *pw_passwd; // Hashed passphrase (deprecated)
+        uid_t pw_uid;    // User ID
+        gid_t pw_gid;    // Group ID
+        char *pw_gecos;  // Real name
+        char *pw_dir;    // Home directory
+        char *pw_shell;  // Shell program
+    */
+    char *field = line;
+    char *next;
+    parse_status_t status;
+
+    READ_STR(':', result->pw_name);
+    READ_STR(':', result->pw_passwd);
+    READ_UINT(':', &result->pw_uid);
+    READ_UINT(':', &result->pw_gid);
+    READ_STR(':', result->pw_gecos);
+    READ_STR(':', result->pw_dir);
+    ASSERT_FINAL_FIELD(':');
+    READ_STR('\n', result->pw_shell);
+
+    return PARSE_OK;
+}
+
+parse_status_t parse_shadow_line(char *line, size_t linelen, size_t buflen,
+                                 void *result_any) {
+    struct spwd *result = result_any;
+    (void)linelen;
+    (void)buflen;
+
+    /* field list of struct spwd (from shadow.h)
+        char *sp_namp;             // Login name
+        char *sp_pwdp;             // Hashed passphrase
+        long int sp_lstchg;        // Date of last change
+        long int sp_min;           // Min days between changes
+        long int sp_max;           // Max days between changes
+        long int sp_warn;          // Days until warn user to change password
+        long int sp_inact;         // Days until the account goes inactive
+        long int sp_expire;        // Days since 1970-01-01 until expires
+        unsigned long int sp_flag; // Reserved
+    */
+    char *field = line;
+    char *next;
+    parse_status_t status;
+
+    READ_STR(':', result->sp_namp);
+    READ_STR(':', result->sp_pwdp);
+    READ_LONG(':', &result->sp_lstchg);
+    READ_LONG(':', &result->sp_min);
+    READ_LONG(':', &result->sp_max);
+    READ_LONG(':', &result->sp_warn);
+    READ_LONG(':', &result->sp_inact);
+    READ_LONG(':', &result->sp_expire);
+    ASSERT_FINAL_FIELD(':');
+    READ_ULONG('\n', &result->sp_flag);
+
+    return PARSE_OK;
+}
+
+parse_status_t parse_group_line(char *line, size_t linelen, size_t buflen,
+                                void *result_any) {
+    struct group *result = result_any;
+
+    /* field list of struct group (from group.h)
+        char *gr_name;   // Group name
+        char *gr_passwd; // Password
+        gid_t gr_gid;    // Group ID
+        char **gr_mem;   // Member list
+    */
+    char *field = line;
+    char *next;
+    parse_status_t status;
+
+    READ_STR(':', result->gr_name);
+    READ_STR(':', result->gr_passwd);
+    READ_UINT(':', &result->gr_gid);
+    ASSERT_FINAL_FIELD(':');
+
+    /* figure out how much space there is for the group member list, which
+       gets embedded directly into the char* buf that the user provides */
+    if (buflen < linelen + 1) {
+        // This should never happen, but avoid underflow anyway.
+        return PARSE_SHORT_BUFFER;
+    }
+    size_t leftover = buflen - (linelen + 1);
+    size_t nmem_max = leftover / sizeof(*result->gr_mem);
+    result->gr_mem = (char **)(line + linelen + 1);
+
+    // Gr_mem must have space to be NULL-terminated.
+    if (nmem_max < 1) {
+        return PARSE_SHORT_BUFFER;
+    }
+
+    // Group membership, a comma-separated list.
+    size_t nmem = 0;
+    bool last = false;
+    while (!last) {
+        // Try to read a comma-separated field.
+        status = get_field(field, ',', &next);
+        if (status == PARSE_INVALID) {
+            // Try again, this time looking for the end of the list.
+            last = true;
+            status = get_field(field, '\n', &next);
+        }
+        if (status) return status;
+
+        if (field[0] != '\0') {
+            if (nmem == nmem_max) return PARSE_SHORT_BUFFER;
+            result->gr_mem[nmem++] = field;
+        }
+
+        field = next;
+    }
+
+    // NULL-terminate the list.
+    if (nmem == nmem_max) return PARSE_SHORT_BUFFER;
+    result->gr_mem[nmem++] = NULL;
+
+    return PARSE_OK;
+}
+
+/* Generic logic for reading a file line-by-line, parsing each line according
+   to a parse_line_fn, and returning the next valid result. */
+parse_status_t fgetent_any(FILE *f, parse_line_fn parse_line, void *result_any,
+                           char *buf, size_t buflen) {
+    parse_status_t status;
+
+    while (true) {
+        // Record where we are in the stream.
+        long start = ftell(f);
+
+        // Read the next line in the file.
+        size_t linelen;
+        status = read_line(f, buf, buflen, &linelen);
+        if (status == PARSE_SHORT_BUFFER) {
+            DEBUG("short buffer after read_line");
+            if (fseek(f, start, SEEK_SET)) {
+                // Unknown failure.
+                return PARSE_FAIL;
+            }
+        } else if (status) {
+            return status;
+        }
+
+        // Parse the line using the parse_line function pointer.
+        status = parse_line(buf, linelen, buflen, result_any);
+        if (status == PARSE_SHORT_BUFFER) {
+            DEBUG("short buffer after parse_line");
+            // We'll try again from the same point in the file.
+            if (fseek(f, start, SEEK_SET)) {
+                // Unknown failure.
+                return PARSE_FAIL;
+            }
+            return PARSE_SHORT_BUFFER;
+        } else if (status == PARSE_INVALID) {
+            DEBUG("skipping invalid line");
+            continue;
+        } else if (status) {
+            return status;
+        }
+
+        break;
+    }
+    return PARSE_OK;
+}

--- a/libnss_determined/src/passwd.c
+++ b/libnss_determined/src/passwd.c
@@ -1,0 +1,89 @@
+#include "libnss_determined.h"
+
+/*
+passwd database functions for listing users:
+
+    These are called to list users in the database:
+        _nss_determined_setpwent
+        _nss_determined_getpwent_r
+        _nss_determined_endpwent
+
+    This is called to look up a user by name:
+        _nss_determined_getpwnam_r
+
+    This is called to look up a user by uid:
+        _nss_determined_getpwuid_r
+*/
+
+FILE *g_passwd_f = NULL;
+
+static void clear_pwd_result(void *result_any, char *buf, size_t buflen) {
+    struct passwd *result = result_any;
+    *result = (struct passwd){0};
+    memset(buf, 0, buflen);
+}
+
+static db_iface_t pwd_db = {
+    .parse_line = parse_pwd_line,
+    .clear_result = clear_pwd_result,
+};
+
+enum nss_status _nss_determined_setpwent(int stayopen) {
+    DEBUG("called, stayopen=%d", stayopen);
+
+    det_nss_status_t det_nss_status = det_fopen(PASSWDFILE, &g_passwd_f);
+
+    return set_errnop_and_return_nss_status(det_nss_status, &errno);
+}
+
+enum nss_status _nss_determined_getpwent_r(struct passwd *result, char *buf,
+                                           size_t buflen, int *errnop) {
+    DEBUG("called");
+
+    det_nss_status_t det_nss_status = getent_any(
+        PASSWDFILE, &g_passwd_f, &pwd_db, (void *)result, buf, buflen);
+
+    return set_errnop_and_return_nss_status(det_nss_status, errnop);
+}
+
+enum nss_status _nss_determined_endpwent(void) {
+    DEBUG("called");
+    if (g_passwd_f) fclose(g_passwd_f);
+    return NSS_STATUS_SUCCESS;
+}
+
+bool pwd_match_name(void *id, void *result_any) {
+    char *name = id;
+    struct passwd *result = result_any;
+    return strcmp(name, result->pw_name) == 0;
+}
+
+enum nss_status _nss_determined_getpwnam_r(const char *name,
+                                           struct passwd *result, char *buf,
+                                           size_t buflen, int *errnop) {
+    DEBUG("called, name=%s", name);
+
+    det_nss_status_t det_nss_status =
+        searchent_any(PASSWDFILE, &pwd_db, pwd_match_name, (void *)name,
+                      (void *)result, buf, buflen);
+
+    return set_errnop_and_return_nss_status(det_nss_status, errnop);
+}
+
+bool pwd_match_uid(void *id, void *result_any) {
+    unsigned int *uid = id;
+    struct passwd *result = result_any;
+    return *uid == result->pw_uid;
+}
+
+enum nss_status _nss_determined_getpwuid_r(uid_t uid, struct passwd *result,
+                                           char *buf, size_t buflen,
+                                           int *errnop) {
+    DEBUG("called, uid=%u", uid);
+
+    det_nss_status_t det_nss_status =
+        searchent_any(PASSWDFILE, &pwd_db, pwd_match_uid, (void *)&uid,
+                      (void *)result, buf, buflen);
+
+    return set_errnop_and_return_nss_status(det_nss_status, errnop);
+}

--- a/libnss_determined/src/shadow.c
+++ b/libnss_determined/src/shadow.c
@@ -1,0 +1,68 @@
+#include "libnss_determined.h"
+
+/*
+shadow database functions for listing hashes of passwords:
+
+    These are called to list passwords in the database:
+        _nss_determined_setspent
+        _nss_determined_getspent_r
+        _nss_determined_endspent
+
+    This is called to look up a password by username:
+        _nss_determined_getspnam_r
+*/
+
+FILE *g_shadow_f = NULL;
+
+static void clear_shadow_result(void *result_any, char *buf, size_t buflen) {
+    struct spwd *result = result_any;
+    *result = (struct spwd){0};
+    memset(buf, 0, buflen);
+}
+
+static db_iface_t shadow_db = {
+    .parse_line = parse_shadow_line,
+    .clear_result = clear_shadow_result,
+};
+
+enum nss_status _nss_determined_setspent(int stayopen) {
+    DEBUG("called, stayopen=%d", stayopen);
+
+    det_nss_status_t det_nss_status = det_fopen(SHADOWFILE, &g_shadow_f);
+
+    return set_errnop_and_return_nss_status(det_nss_status, &errno);
+}
+
+enum nss_status _nss_determined_getspent_r(struct spwd *result, char *buf,
+                                           size_t buflen, int *errnop) {
+    DEBUG("called");
+
+    det_nss_status_t det_nss_status = getent_any(
+        SHADOWFILE, &g_shadow_f, &shadow_db, (void *)result, buf, buflen);
+
+    return set_errnop_and_return_nss_status(det_nss_status, errnop);
+}
+
+enum nss_status _nss_determined_endspent(void) {
+    DEBUG("called");
+    if (g_shadow_f) fclose(g_shadow_f);
+    return NSS_STATUS_SUCCESS;
+}
+
+bool shadow_match_name(void *id, void *result_any) {
+    char *name = id;
+    struct spwd *result = result_any;
+    return strcmp(name, result->sp_namp) == 0;
+}
+
+enum nss_status _nss_determined_getspnam_r(const char *name,
+                                           struct spwd *result, char *buf,
+                                           size_t buflen, int *errnop) {
+    DEBUG("called, name=%s", name);
+
+    det_nss_status_t det_nss_status =
+        searchent_any(SHADOWFILE, &shadow_db, shadow_match_name, (void *)name,
+                      (void *)result, buf, buflen);
+
+    return set_errnop_and_return_nss_status(det_nss_status, errnop);
+}

--- a/libnss_determined/src/util.c
+++ b/libnss_determined/src/util.c
@@ -1,0 +1,145 @@
+#include "libnss_determined.h"
+
+bool debug_mode = false;
+bool debug_mode_checked = false;
+
+enum nss_status set_errnop_and_return_nss_status(
+    det_nss_status_t det_nss_status, int *errnop) {
+    switch (det_nss_status) {
+        case DET_NSS_STATUS_OK:
+            // The docs say: "An NSS module should never set *errnop to zero".
+            return NSS_STATUS_SUCCESS;
+
+        case DET_NSS_STATUS_SHORT_BUFFER:
+            *errnop = ERANGE;
+            return NSS_STATUS_TRYAGAIN;
+
+        case DET_NSS_STATUS_MISSING_FILE:
+            *errnop = ENOENT;
+            return NSS_STATUS_UNAVAIL;
+
+        case DET_NSS_STATUS_END_OF_ENTRIES:
+            /* Presumably, since this is a very specific error condition, the
+               docs which say to never set *errnop to zero do not apply. */
+            *errnop = 0;
+            return NSS_STATUS_NOTFOUND;
+
+        case DET_NSS_STATUS_ENTRY_NOT_FOUND:
+            *errnop = ENOENT;
+            return NSS_STATUS_NOTFOUND;
+
+        case DET_NSS_STATUS_FAIL:
+        default:
+            *errnop = EAGAIN;
+            return NSS_STATUS_TRYAGAIN;
+    }
+}
+
+det_nss_status_t det_fopen(char *filename, FILE **f) {
+    *f = fopen(filename, "r");
+    if (!*f) {
+        if (errno == ENOENT) {
+            DEBUG("missing file");
+            return DET_NSS_STATUS_MISSING_FILE;
+        }
+        DEBUG("unknown failure");
+        return DET_NSS_STATUS_FAIL;
+    }
+    DEBUG("OK");
+    return DET_NSS_STATUS_OK;
+}
+
+det_nss_status_t getent_any(char *filename, FILE **f, db_iface_t *db_iface,
+                            void *result_any, char *buf, size_t buflen) {
+    det_nss_status_t det_nss_status = DET_NSS_STATUS_OK;
+
+    /* The docs indicate that setent might not have been called:
+
+          "When the service was not formerly initialized by a call to
+          _nss_DATABASE_setdbent all return values allowed for this function
+          can also be returned here."
+
+       So we detect that case and call fopen here instead.
+
+       gnu.org/software/libc/manual/html_node/NSS-Module-Function-Internals.html
+    */
+    if (!*f) {
+        det_nss_status = det_fopen(filename, f);
+        if (det_nss_status) {
+            goto done;
+        }
+    }
+
+    parse_status_t parse;
+    parse = fgetent_any(*f, db_iface->parse_line, result_any, buf, buflen);
+    switch (parse) {
+        case PARSE_OK:
+            goto done;
+
+        case PARSE_SHORT_BUFFER:
+            det_nss_status = DET_NSS_STATUS_SHORT_BUFFER;
+            goto done;
+
+        case PARSE_EOF:
+            det_nss_status = DET_NSS_STATUS_END_OF_ENTRIES;
+            goto done;
+
+        case PARSE_INVALID:
+        case PARSE_FAIL:
+            break;
+    }
+    det_nss_status = DET_NSS_STATUS_FAIL;
+
+done:
+    if (det_nss_status) {
+        db_iface->clear_result(result_any, buf, buflen);
+    }
+    return det_nss_status;
+}
+
+det_nss_status_t searchent_any(char *filename, db_iface_t *db_iface,
+                               match_fn match, void *id, void *result_any,
+                               char *buf, size_t buflen) {
+    FILE *f = NULL;
+    det_nss_status_t det_nss_status = det_fopen(filename, &f);
+    if (det_nss_status) {
+        return det_nss_status;
+    }
+
+    while (true) {
+        parse_status_t parse;
+        parse = fgetent_any(f, db_iface->parse_line, result_any, buf, buflen);
+        switch (parse) {
+            case PARSE_OK:
+                // Is this the right entry?
+                if (match(id, result_any)) {
+                    det_nss_status = DET_NSS_STATUS_OK;
+                    goto done;
+                }
+                break;
+
+            case PARSE_SHORT_BUFFER:
+                det_nss_status = DET_NSS_STATUS_SHORT_BUFFER;
+                goto done;
+
+            case PARSE_EOF:
+                det_nss_status = DET_NSS_STATUS_ENTRY_NOT_FOUND;
+                goto done;
+
+            case PARSE_INVALID:
+            case PARSE_FAIL:
+            default:
+                det_nss_status = DET_NSS_STATUS_FAIL;
+                goto done;
+        }
+    }
+
+done:
+    if (f) {
+        fclose(f);
+    }
+    if (det_nss_status) {
+        db_iface->clear_result(result_any, buf, buflen);
+    }
+    return det_nss_status;
+}

--- a/libnss_determined/test/integration_test.sh
+++ b/libnss_determined/test/integration_test.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -e
+
+die () {
+    echo -e "\x1b[31mfailed testing $@\x1b[m"
+    exit 1
+}
+
+# Run tests in valgrind to ensure we don't have memory errors.
+valgrind="valgrind --quiet --leak-check=full --show-leak-kinds=all"
+valgrind="$valgrind --error-exitcode=255 --exit-on-first-error=yes"
+
+run_grep_test () {
+    action="$1"
+    answer="$2"
+
+    echo -n "testing $action... "
+    got="$(docker run libnss_determined_test $valgrind $action)"
+    echo "$got" | grep -q "$answer" || die $action
+    echo "PASS"
+}
+
+run_exact_test () {
+    action="$1"
+    answer="$2"
+
+    echo -n "testing $action... "
+    got="$(docker run libnss_determined_test $valgrind $action)"
+    test "$got" = "$answer" || die $action
+    echo "PASS"
+}
+
+docker build . -t libnss_determined_test || die build
+
+passwd_line="user:x:1000:1000::/home/user:/bin/bash"
+shadow_line="user:THEHASH:18459::::::"
+group_line="user:x:1000:"
+
+run_grep_test "getent passwd" "$passwd_line"
+run_exact_test "getent passwd user" "$passwd_line"
+run_exact_test "getent passwd 1000" "$passwd_line"
+
+run_grep_test "getent shadow" "$shadow_line"
+run_exact_test "getent shadow user" "$shadow_line"
+
+run_grep_test "getent group" "$group_line"
+run_exact_test "getent group user" "$group_line"
+run_exact_test "getent group 1000" "$group_line"

--- a/libnss_determined/test/unit_test.c
+++ b/libnss_determined/test/unit_test.c
@@ -1,0 +1,425 @@
+#include <libnss_determined.h>
+
+static char *parse_status_names[] = {
+    "PARSE_OK",      "PARSE_SHORT_BUFFER", "PARSE_EOF",
+    "PARSE_INVALID", "PARSE_FAIL",
+};
+
+#define EXPECT_STATUS(got, exp)                                            \
+    do {                                                                   \
+        if (got != exp) {                                                  \
+            fprintf(stderr, "%s():%d: got %s but expected %s\n", __func__, \
+                    __LINE__, parse_status_names[got],                     \
+                    parse_status_names[exp]);                              \
+            return 1;                                                      \
+        }                                                                  \
+    } while (0)
+
+#define EXPECT_STRING(got, exp)                                          \
+    do {                                                                 \
+        if (strncmp(got, exp, strlen(exp) + 1) != 0) {                   \
+            fprintf(stderr, "%s():%d: got \"%s\" but expected \"%s\"\n", \
+                    __func__, __LINE__, got, exp);                       \
+            return 1;                                                    \
+        }                                                                \
+    } while (0)
+
+#define EXPECT_NULL_STRING(got)                                        \
+    do {                                                               \
+        if (got != NULL) {                                             \
+            fprintf(stderr, "%s():%d: got \"%s\" but expected NULL\n", \
+                    __func__, __LINE__, got);                          \
+            return 1;                                                  \
+        }                                                              \
+    } while (0)
+
+#define EXPECT_UINT(got, exp)                                              \
+    do {                                                                   \
+        if (got != exp) {                                                  \
+            fprintf(stderr, "%s():%d: got %u but expected %u\n", __func__, \
+                    __LINE__, got, exp);                                   \
+            return 1;                                                      \
+        }                                                                  \
+    } while (0)
+
+#define EXPECT_LONG(got, exp)                                                \
+    do {                                                                     \
+        if (got != exp) {                                                    \
+            fprintf(stderr, "%s():%d: got %ld but expected %ld\n", __func__, \
+                    __LINE__, got, exp);                                     \
+            return 1;                                                        \
+        }                                                                    \
+    } while (0)
+
+#define EXPECT_ULONG(got, exp)                                               \
+    do {                                                                     \
+        if (got != exp) {                                                    \
+            fprintf(stderr, "%s():%d: got %lu but expected %lu\n", __func__, \
+                    __LINE__, got, exp);                                     \
+            return 1;                                                        \
+        }                                                                    \
+    } while (0)
+
+int test_get_field(void) {
+    parse_status_t status;
+    char line[] = "a:sdf::  :zxcv\n";
+    char *field = line;
+    char *next;
+
+    status = get_field(field, ':', &next);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(field, "a");
+    field = next;
+
+    status = get_field(field, ':', &next);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(field, "sdf");
+    field = next;
+
+    status = get_field(field, ':', &next);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(field, "");
+    field = next;
+
+    status = get_field(field, ':', &next);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(field, "  ");
+    field = next;
+
+    // Fail if you expect too many ':' separators.
+    status = get_field(field, ':', &next);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    status = get_field(field, '\n', &next);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(field, "zxcv");
+    field = next;
+
+    // Fail on an empty string
+    status = get_field(field, ':', &next);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    return 0;
+}
+
+int test_read_uint(void) {
+    parse_status_t status;
+    char *field;
+    unsigned int result;
+
+    field = "0";
+    status = read_uint(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_UINT(result, 0);
+
+    field = "";
+    status = read_uint(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_UINT(result, 0);
+
+    field = "12345";
+    status = read_uint(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_UINT(result, 12345);
+
+    field = "12345 ";
+    status = read_uint(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "12.345";
+    status = read_uint(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "-12345";
+    status = read_uint(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = " ";
+    status = read_uint(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "99999999999999999999";
+    status = read_uint(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    return 0;
+}
+
+int test_read_long(void) {
+    parse_status_t status;
+    char *field;
+    long int result;
+
+    field = "0";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_LONG(result, 0L);
+
+    // For shadow.h: empty fields become -1.
+    field = "";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_LONG(result, -1L);
+
+    field = "12345";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_LONG(result, 12345L);
+
+    field = "-12345";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_LONG(result, -12345L);
+
+    field = "12345 ";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "12.345";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = " ";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "99999999999999999999";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "-99999999999999999999";
+    status = read_long(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    return 0;
+}
+
+int test_read_ulong(void) {
+    parse_status_t status;
+    char *field;
+    unsigned long int result;
+
+    field = "0";
+    status = read_ulong(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_LONG(result, 0UL);
+
+    // For shadow.h: empty fields become -1.
+    field = "";
+    status = read_ulong(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_LONG(result, -1UL);
+
+    field = "12345";
+    status = read_ulong(field, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_LONG(result, 12345UL);
+
+    field = "12345 ";
+    status = read_ulong(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "12.345";
+    status = read_ulong(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "-12345";
+    status = read_ulong(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = " ";
+    status = read_ulong(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    field = "99999999999999999999";
+    status = read_ulong(field, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    return 0;
+}
+
+int test_parse_pwd_line(void) {
+    parse_status_t status;
+    struct passwd result;
+    char line[100];
+
+    strncpy(line, "root:x:0:0::/root:/bin/bash\n", sizeof(line));
+    status = parse_pwd_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(result.pw_name, "root");
+    EXPECT_STRING(result.pw_passwd, "x");
+    EXPECT_UINT(result.pw_uid, 0);
+    EXPECT_UINT(result.pw_gid, 0);
+    EXPECT_STRING(result.pw_gecos, "");
+    EXPECT_STRING(result.pw_dir, "/root");
+    EXPECT_STRING(result.pw_shell, "/bin/bash");
+
+    // Reject extra fields.
+    strncpy(line, "root:x:0:0::/root:/bin/bash:\n", sizeof(line));
+    status = parse_pwd_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    // Reject malformed lines.
+    strncpy(line, "root:x:0:0::/root:/bin/bash", sizeof(line));
+    status = parse_pwd_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    strncpy(line, "root:x:0:0::/root", sizeof(line));
+    status = parse_pwd_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    // No segfault on empty strings.
+    strncpy(line, "", sizeof(line));
+    status = parse_pwd_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    return 0;
+}
+
+int test_parse_shadow_line(void) {
+    parse_status_t status;
+    struct spwd result;
+    char line[100];
+
+    strncpy(line, "user:THE_HASH:18035:0:99999:7:::\n", sizeof(line));
+    status = parse_shadow_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(result.sp_namp, "user");
+    EXPECT_STRING(result.sp_pwdp, "THE_HASH");
+    EXPECT_LONG(result.sp_lstchg, 18035L);
+    EXPECT_LONG(result.sp_min, 0L);
+    EXPECT_LONG(result.sp_max, 99999L);
+    EXPECT_LONG(result.sp_warn, 7L);
+    EXPECT_LONG(result.sp_inact, -1L);
+    EXPECT_LONG(result.sp_expire, -1L);
+    EXPECT_ULONG(result.sp_flag, -1UL);
+
+    // Reject extra fields.
+    strncpy(line, "user:THE_HASH:18035:0:99999:7::::\n", sizeof(line));
+    status = parse_shadow_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    // Reject malformed lines.
+    strncpy(line, "user:THE_HASH:18035:0:99999:7::\n", sizeof(line));
+    status = parse_shadow_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    strncpy(line, "user:THE_HASH:18035:0:99999:7:::", sizeof(line));
+    status = parse_shadow_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    // No segfault on empty strings.
+    strncpy(line, "", sizeof(line));
+    status = parse_shadow_line(line, strlen(line), strlen(line) + 1, &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    return 0;
+}
+
+int test_parse_group_line(void) {
+    parse_status_t status;
+    struct group result;
+    char line[100];
+
+    strncpy(line, "sudo:x:1:a,b,c\n", sizeof(line));
+    status = parse_group_line(line, strlen(line), sizeof(line), &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(result.gr_name, "sudo");
+    EXPECT_STRING(result.gr_passwd, "x");
+    EXPECT_STRING(result.gr_mem[0], "a");
+    EXPECT_STRING(result.gr_mem[1], "b");
+    EXPECT_STRING(result.gr_mem[2], "c");
+    EXPECT_NULL_STRING(result.gr_mem[3]);
+
+    // Empty membership list.
+    strncpy(line, "sudo:x:1:\n", sizeof(line));
+    status = parse_group_line(line, strlen(line), sizeof(line), &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(result.gr_name, "sudo");
+    EXPECT_STRING(result.gr_passwd, "x");
+    EXPECT_NULL_STRING(result.gr_mem[0]);
+
+    // No commas in membership list.
+    strncpy(line, "sudo:x:1:a\n", sizeof(line));
+    status = parse_group_line(line, strlen(line), sizeof(line), &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(result.gr_name, "sudo");
+    EXPECT_STRING(result.gr_passwd, "x");
+    EXPECT_STRING(result.gr_mem[0], "a");
+    EXPECT_NULL_STRING(result.gr_mem[1]);
+
+    // No segfault on empty strings.
+    strncpy(line, "", sizeof(line));
+    status = parse_group_line(line, strlen(line), sizeof(line), &result);
+    EXPECT_STATUS(status, PARSE_INVALID);
+
+    // Buffer too short.
+    strncpy(line, "sudo:x:1:\n", sizeof(line));
+    status = parse_group_line(line, strlen(line),
+                              (strlen(line) + 1) + sizeof(*result.gr_mem) - 1,
+                              &result);
+    EXPECT_STATUS(status, PARSE_SHORT_BUFFER);
+
+    strncpy(line, "sudo:x:1:a\n", sizeof(line));
+    status = parse_group_line(
+        line, strlen(line), (strlen(line) + 1) + 2 * sizeof(*result.gr_mem) - 1,
+        &result);
+    EXPECT_STATUS(status, PARSE_SHORT_BUFFER);
+
+    // Buffer just long enough.
+    strncpy(line, "sudo:x:1:a\n", sizeof(line));
+    status = parse_group_line(
+        line, strlen(line), (strlen(line) + 1) + 2 * sizeof(*result.gr_mem) - 1,
+        &result);
+    EXPECT_STATUS(status, PARSE_SHORT_BUFFER);
+
+    // Buffer just long enough.
+    strncpy(line, "sudo:x:1:a\n", sizeof(line));
+    status = parse_group_line(line, strlen(line),
+                              (strlen(line) + 1) + 2 * sizeof(*result.gr_mem),
+                              &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(result.gr_name, "sudo");
+    EXPECT_STRING(result.gr_passwd, "x");
+    EXPECT_STRING(result.gr_mem[0], "a");
+    EXPECT_NULL_STRING(result.gr_mem[1]);
+
+    // Ignore empty entries in membership list.
+    strncpy(line, "sudo:x:1:a,,\n", sizeof(line));
+    status = parse_group_line(line, strlen(line),
+                              (strlen(line) + 1) + 2 * sizeof(*result.gr_mem),
+                              &result);
+    EXPECT_STATUS(status, PARSE_OK);
+    EXPECT_STRING(result.gr_name, "sudo");
+    EXPECT_STRING(result.gr_passwd, "x");
+    EXPECT_STRING(result.gr_mem[0], "a");
+    EXPECT_NULL_STRING(result.gr_mem[1]);
+
+    return 0;
+}
+
+#define RUN_TEST(name)                            \
+    do {                                          \
+        if (name()) {                             \
+            fprintf(stderr, #name "() failed\n"); \
+            failed = true;                        \
+        }                                         \
+    } while (0)
+
+int main() {
+    bool failed = false;
+
+    RUN_TEST(test_get_field);
+    RUN_TEST(test_read_uint);
+    RUN_TEST(test_read_long);
+    RUN_TEST(test_read_ulong);
+    RUN_TEST(test_parse_pwd_line);
+    RUN_TEST(test_parse_shadow_line);
+    RUN_TEST(test_parse_group_line);
+
+    if (!failed) {
+        printf("PASS\n");
+    }
+
+    return (int)failed;
+}


### PR DESCRIPTION
libnss_determined is a plugin to glibc's name switch service.  It allows
us to provision users in the container at runtime, which allows for easy
support of features like sshd and distributed training in non-root
containers.

## Details

About half of the code is dedicated to implementing parsing functions.  I originally used the built-in `fgetpwent`, `fgetgrent`, and `fgetspent` for reading lines out of files formatted like `/etc/passwd`, `/etc/group`, and `/etc/shadow`, respectively, but those broke in our containers due to `LC_*` environment variables.  Probably we could do something to the locale in the container to fix the underlying issue, but I figure if we expect users to include this thing in their custom environments, we should just implement the parsing ourselves in a way that is robust to `LC_*`.  The good news is, we will only parse files that we write ourselves, so the parsing doesn't even have to be all that robust to begin with.

## Test plan

I have added unit tests and integration tests for the `libnss_determined.so.2` plugin as part of this change.

The master will also have e2e tests before this feature is complete.