### PR TITLE
fix: Update version of Nvidia driver in cloud images.

### DIFF
--- a/cloud/roles/nvidia-drivers/defaults/main.yml
+++ b/cloud/roles/nvidia-drivers/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # NVIDIA Driver Settings
-driver_version: "410.104"
+driver_version: "450.51.05"
 driver_script_name: "NVIDIA-Linux-x86_64-{{ driver_version }}.run"
-driver_url: "http://us.download.nvidia.com/XFree86/Linux-x86_64/{{ driver_version }}/{{ driver_script_name }}"
+driver_url: "https://us.download.nvidia.com/tesla/{{ driver_version }}/{{ driver_script_name }}"


### PR DESCRIPTION
Upgrade from 410.104 to 450.51.05. This apparently is necessary to get
T4 chips to work on G4 AWS instances. This driver *should* be compatible
with older versions of CUDA -- I tested with CUDA 10.0 only.

Along the way, switch from the "XFree86" package to the "Tesla" package.
It is a little unclear what the difference is, but the Nvidia download
site guides you to the latter when you're using enterprise GPUs, which
should always be the case in public cloud environments.