### PR TITLE
fix: Update to reflect change in NVIDIA GLX paths.

### DIFF
--- a/cloud/roles/nvidia-drivers/tasks/main.yml
+++ b/cloud/roles/nvidia-drivers/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Unarchive NVIDIA Persistence Daemon.
   become: yes
   unarchive:
-    src: /usr/share/doc/NVIDIA_GLX-1.0/sample/nvidia-persistenced-init.tar.bz2
+    src: /usr/share/doc/NVIDIA_GLX-1.0/samples/nvidia-persistenced-init.tar.bz2
     dest: /tmp
     remote_src: yes
 


### PR DESCRIPTION
The path to the persistence daemon change when the Nvidia drivers were
upgraded in #45.