### PR TITLE
Save parsable artifacts after publishing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
       - docker-login
       - run: make build-<<parameters.image-type>>
       - run: make publish-<<parameters.image-type>>
+      - store_artifacts:
+          path: /tmp/artifacts
 
   publish-cloud-images:
     docker:
@@ -68,6 +70,8 @@ jobs:
       - run:
           no_output_timeout: 60m
           command: make publish-cloud-images
+      - store_artifacts:
+          path: /tmp/artifacts
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ CPU_SUFFIX := -cpu
 CUDA_100_PREFIX := determinedai/environments:cuda-10.0-
 CUDA_101_PREFIX := determinedai/environments:cuda-10.1-
 GPU_SUFFIX := -gpu
+ARTIFACTS_DIR := /tmp/artifacts
 
 export CPU_TF1_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.4-tf-1.15$(CPU_SUFFIX)
 export GPU_TF1_ENVIRONMENT_NAME := $(CUDA_100_PREFIX)pytorch-1.4-tf-1.15$(GPU_SUFFIX)
@@ -67,24 +68,23 @@ build-tf2-gpu:
 
 .PHONY: publish-tf1-cpu
 publish-tf1-cpu:
-	docker push $(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH)
-	docker push $(CPU_TF1_ENVIRONMENT_NAME)-$(VERSION)
+	scripts/publish-docker.sh tf1-cpu $(CPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-tf2-cpu
 publish-tf2-cpu:
-	docker push $(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH)
-	docker push $(CPU_TF2_ENVIRONMENT_NAME)-$(VERSION)
+	scripts/publish-docker.sh tf2-cpu $(CPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-tf1-gpu
 publish-tf1-gpu:
-	docker push $(GPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH)
-	docker push $(GPU_TF1_ENVIRONMENT_NAME)-$(VERSION)
+	scripts/publish-docker.sh tf1-gpu $(GPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-tf2-gpu
 publish-tf2-gpu:
-	docker push $(GPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH)
-	docker push $(GPU_TF2_ENVIRONMENT_NAME)-$(VERSION)
+	scripts/publish-docker.sh tf2-gpu $(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-cloud-images
 publish-cloud-images:
-	cd cloud && packer build -var "image_suffix=-$(SHORT_GIT_HASH)" environments-packer.json
+	mkdir -p $(ARTIFACTS_DIR)
+	cd cloud \
+		&& packer build -machine-readable -var "image_suffix=-$(SHORT_GIT_HASH)" environments-packer.json \
+		| tee $(ARTIFACTS_DIR)/packer-log

--- a/scripts/publish-docker.sh
+++ b/scripts/publish-docker.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+set -x
+
+if [ "$#" -ne 5 ] ; then
+    echo "usage: $0 LOG_NAME BASE_TAG HASH VERSION ARTIFACTS_DIR" >&2
+    exit 1
+fi
+
+log_name="$1"
+base_tag="$2"
+hash="$3"
+version="$4"
+artifacts="$5"
+
+underscore_name="$(echo -n "$log_name" | tr - _)"
+
+docker push "$base_tag-$hash"
+docker push "$base_tag-$version"
+
+mkdir -p "$artifacts"
+
+log_file="$artifacts/publish-$log_name"
+(
+    echo "${underscore_name}_hashed: $base_tag-$hash"
+    echo "${underscore_name}_versioned: $base_tag-$version"
+) > "$log_file"


### PR DESCRIPTION
The artifacts will eventually be consumed by scripts in the main
Determined repository for automatically updating the image tags.