### PR TITLE
Build GCP imags with kdump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ version: 2.1
 orbs:
   gcp-cli: circleci/gcp-cli@1.8.4
 
+any-upstream-branch: &any-upstream-branch
+  branches:
+    ignore:
+      - /pull\/.*/
+
 commands:
   docker-login:
     steps:
@@ -74,7 +79,6 @@ jobs:
           path: /tmp/artifacts
 
 
-
 workflows:
   publish:
     jobs:
@@ -83,14 +87,10 @@ workflows:
           matrix:
             parameters:
               image-type: ["tf1-cpu", "tf2-cpu", "tf1-gpu", "tf2-gpu"]
-          filters:
-            branches:
-              only: master
+          filters: *any-upstream-branch
 
       - publish-cloud-images:
           context: determined-production
           requires:
             - build-and-publish-docker
-          filters:
-            branches:
-              only: master
+          filters: *any-upstream-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,15 +82,6 @@ jobs:
 workflows:
   publish:
     jobs:
-      - build-and-publish-docker:
-          context: determined-production
-          matrix:
-            parameters:
-              image-type: ["tf1-cpu", "tf2-cpu", "tf1-gpu", "tf2-gpu"]
-          filters: *any-upstream-branch
-
       - publish-cloud-images:
           context: determined-production
-          requires:
-            - build-and-publish-docker
           filters: *any-upstream-branch

--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -25,24 +25,6 @@
       "extra_arguments": [
         "--verbose",
         "-e ansible_python_interpreter=/usr/bin/python3",
-        "-e linux_kernel_suffix=aws",
-        "-e build_type={{ build_type }}",
-        "-e gpu_tf1_environment_name={{ user `gpu_tf1_environment_name` }}",
-        "-e cpu_tf1_environment_name={{ user `cpu_tf1_environment_name` }}",
-        "-e gpu_tf2_environment_name={{ user `gpu_tf2_environment_name` }}",
-        "-e cpu_tf2_environment_name={{ user `cpu_tf2_environment_name` }}",
-        "-e short_git_hash={{ user `short_git_hash` }}",
-        "-e image_suffix={{ user `image_suffix` }}"
-      ],
-      "user": "ubuntu",
-      "only": ["amazon-ebs"]
-    },
-    {
-      "type": "ansible",
-      "playbook_file": "environments-playbook.yml",
-      "extra_arguments": [
-        "--verbose",
-        "-e ansible_python_interpreter=/usr/bin/python3",
         "-e linux_kernel_suffix=gcp",
         "-e build_type={{ build_type }}",
         "-e gpu_tf1_environment_name={{ user `gpu_tf1_environment_name` }}",
@@ -62,40 +44,6 @@
     }
   ],
   "builders": [
-    {
-      "type": "amazon-ebs",
-      "access_key": "{{ user `aws_access_key_id` }}",
-      "secret_key": "{{ user `aws_secret_access_key` }}",
-      "region": "us-west-2",
-      "ami_regions": [
-          "ap-northeast-1",
-          "ap-northeast-2",
-          "ap-southeast-1",
-          "ap-southeast-2",
-          "eu-central-1",
-          "eu-west-1",
-          "eu-west-2",
-          "us-east-1",
-          "us-east-2"
-      ],
-      "source_ami": "{{ user `aws_base_image`}}",
-      "instance_type": "p2.xlarge",
-      "ssh_username": "ubuntu",
-      "launch_block_device_mappings": [
-        {
-          "device_name": "/dev/sda1",
-          "volume_size": 100,
-          "volume_type": "gp2",
-          "delete_on_termination": true
-        }
-      ],
-      "run_tags": {
-        "managed-by": "packer"
-      },
-      "ami_name": "det-environments{{ user `image_suffix` }}",
-      "ami_description": "{{ user `image_description` }}",
-      "ami_groups": ["all"]
-    },
     {
       "type": "googlecompute",
       "name": "det-environments{{ user `image_suffix` }}",

--- a/cloud/environments-playbook.yml
+++ b/cloud/environments-playbook.yml
@@ -9,4 +9,4 @@
     - { role: nvidia-docker, tags: "nvidia-docker" }
     - { role: journald-cloudwatch, tags: "journald-cloudwatch", when: "build_type == 'amazon-ebs'"}
     - { role: gpumon, tags: "gpumon", when: "build_type == 'amazon-ebs'"}
-    - { role: environments, tags: "nvidia-docker" }
+    - { role: kdump, tags: "kdump"}

--- a/cloud/roles/kdump/tasks/main.yml
+++ b/cloud/roles/kdump/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+- name: Add a repo for kernel debug symbols.
+  become: yes
+  apt_repository:
+    repo: deb http://ddebs.ubuntu.com xenial main restricted universe multiverse
+    state: present
+
+- name: Add a second repo for kernel debug symbols.
+  become: yes
+  apt_repository:
+    repo: deb http://ddebs.ubuntu.com xenial-updates main restricted universe multiverse
+    state: present
+
+- name: Add a third repo for kernel debug symbols.
+  become: yes
+  apt_repository:
+    repo: deb http://ddebs.ubuntu.com xenial-proposed main restricted universe multiverse
+    state: present
+
+- name: Update apt-get.
+  become: yes
+  apt:
+    update_cache: yes
+
+- name: Pre-enable kexec.
+  become: yes
+  debconf:
+    name: kexec-tools
+    question: kexec-tools/load_kexec
+    value: 'true'
+    vtype: select
+
+- name: Pre-enable kdump.
+  become: yes
+  debconf:
+    name: kdump-tools
+    question: kdump-tools/use_kdump
+    value: 'true'
+    vtype: select
+
+- name: Install linux-crashdump and friends.
+  become: yes
+  apt:
+    name:
+    - linux-crashdump
+    state: present
+
+- name: Increase to maximum kdump memory size.
+  become: yes
+  lineinfile:
+    path: /etc/default/grub.d/kdump-tools.cfg
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT='
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT crashkernel=768M"'
+
+- name: Update grub.
+  become: yes
+  command: update-grub
+
+- name: Reboot to ensure that kdump is actually running.
+  become: yes
+  reboot:


### PR DESCRIPTION
The purpose of this PR is not necessarily merge to master, it is to produce a usable GCP image with `kdump` enabled, which is needed to debug a customer bug.

If the `kdump` tooling proves useful, we can consider if enabling `kdump` by default is worth the runtime cost of reserving a section of RAM (the only real cost, AFAIK).