### PR TITLE
chore: remove ssh private keys

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -25,7 +25,10 @@ RUN apt-get update \
 		openssh-server \
 		pkg-config \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm /etc/ssh/ssh_host_ecdsa_key \
+	&& rm /etc/ssh/ssh_host_ed25519_key \
+	&& rm /etc/ssh/ssh_host_rsa_key
 
 ARG CONDA_DIR="/opt/conda"
 ARG CONDA_INSTALLER="Miniconda3-4.7.10-Linux-x86_64.sh"

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -28,7 +28,10 @@ RUN apt-get update \
 		openssh-server \
 		pkg-config \
 		wget \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm /etc/ssh/ssh_host_ecdsa_key \
+	&& rm /etc/ssh/ssh_host_ed25519_key \
+	&& rm /etc/ssh/ssh_host_rsa_key
 
 ARG CONDA_DIR="/opt/conda"
 ARG CONDA_INSTALLER="Miniconda3-4.7.10-Linux-x86_64.sh"


### PR DESCRIPTION
Nvidia's security scan found several exposed private keys - we simply remove them.