### PR TITLE
chore: use Ansible from Ubuntu upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,11 @@ commands:
   install-ansible:
     steps:
       - run:
-          name: Install Ansible
-          command: sudo apt-add-repository --yes --update ppa:ansible/ansible && sudo apt install ansible
+          name: Install Ansible library
+          command: CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip install ansible
+      - run:
+          name: Install Ansible CLI
+          command: sudo apt install -y ansible
 
   install-docker:
     steps:


### PR DESCRIPTION
The previous installation procedure hits this error: "The repository 'http://ppa.launchpad.net/ansible/ansible/ubuntu focal Release' does not have a Release file." Indeed there's no distribution here for Focal (Ubuntu 20.04): http://ppa.launchpad.net/ansible/ansible/ubuntu/dists/.

Just using upstream Ansible for now until this can get resolved.