### PR TITLE
chore: also install Ansible Python package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,11 @@ commands:
   install-ansible:
     steps:
       - run:
-          name: Install Ansible
+          name: Install Ansible CLI
           command: sudo apt-add-repository --yes --update ppa:ansible/ansible && sudo apt install ansible
+      - run:
+          name: Install Ansible library
+          command: CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip install ansible
 
   install-docker:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,14 @@ commands:
   install-ansible:
     steps:
       - run:
+          name: Install Rust compiler (required for Python cryptography)
+          command: sudo apt install -y rustc
+      - run:
           name: Install Ansible CLI
           command: sudo apt-add-repository --yes --update ppa:ansible/ansible && sudo apt install ansible
       - run:
           name: Install Ansible library
-          command: CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip install ansible
+          command: pip install ansible
 
   install-docker:
     steps:


### PR DESCRIPTION
If you don't install this, the workflow fails because it gets a non-zero status from "ansible-playbook --version". If you dig deeper, it's because some Python code in the CLI tries to import the Ansible Python module and it doesn't exist unless you've installed it. I've reported this on their IRC channel - seems to be the only point of contact I see on Launchpad.

I actually see this in Ubuntu 20.04 in general even when installing the stock / upstream Ansible deb package too. I'm still using the PPA we used to use because as of today, their Ubuntu 20.04 distribution is fixed with the new release.