### PR TITLE
chore: Upgrade pip to avoid need for Rust compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ commands:
   install-ansible:
     steps:
       - run:
-          name: Install Rust compiler (required for Python cryptography)
-          command: sudo apt install -y rustc
+          name: Upgrade Pip # Required to get pre-compiled cryptography wheel
+          command: pip install --upgrade pip
       - run:
           name: Install Ansible CLI
           command: sudo apt-add-repository --yes --update ppa:ansible/ansible && sudo apt install ansible


### PR DESCRIPTION
Turns out we have to `apt-get update` to get the Rust compiler anyway... I've since learning that upgrading Pip is the better long-term solution anyway. Tried this out via a SSH to try and stop this series of band-aids...

(side note: other failures in CircleCI yesterday were because the Hashicorp releases server was misconfigured)