### PR TITLE
build: add pytorch_lightning to env images

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -73,10 +73,12 @@ ARG TENSORFLOW_PIP
 ARG TORCH_PIP
 ARG TORCHVISION_PIP
 ARG TENSORPACK_PIP
+ARG LIGHTNING_PIP
 RUN if [ "$TENSORFLOW_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $TENSORFLOW_PIP; fi
 RUN if [ "$TORCH_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $TORCH_PIP; fi
 RUN if [ "$TORCHVISION_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $TORCHVISION_PIP; fi
 RUN if [ "$TENSORPACK_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $TENSORPACK_PIP; fi
+RUN if [ "$LIGHTNING_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $LIGHTNING_PIP; fi
 
 RUN ${CONDA_DIR}/bin/python3.6 -m pip install determined determined-cli
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -76,10 +76,12 @@ ARG TENSORFLOW_PIP
 ARG TORCH_PIP
 ARG TORCHVISION_PIP
 ARG TENSORPACK_PIP
+ARG LIGHTNING_PIP
 RUN if [ "$TENSORFLOW_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $TENSORFLOW_PIP; fi
 RUN if [ "$TORCH_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $TORCH_PIP; fi
 RUN if [ "$TORCHVISION_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $TORCHVISION_PIP; fi
 RUN if [ "$TENSORPACK_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $TENSORPACK_PIP; fi
+RUN if [ "$LIGHTNING_PIP" ]; then ${CONDA_DIR}/bin/python3.6 -m pip install $LIGHTNING_PIP; fi
 RUN ${CONDA_DIR}/bin/python3.6 -m pip install GPUtil
 
 ARG TORCH_CUDA_ARCH_LIST

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ ARTIFACTS_DIR := /tmp/artifacts
 
 export CPU_TF1_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.7-tf-1.15$(CPU_SUFFIX)
 export GPU_TF1_ENVIRONMENT_NAME := $(CUDA_101_PREFIX)pytorch-1.7-tf-1.15$(GPU_SUFFIX)
-export CPU_TF2_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.7-tf-2.4$(CPU_SUFFIX)
-export GPU_TF2_ENVIRONMENT_NAME := $(CUDA_101_PREFIX)pytorch-1.7-tf-2.4$(GPU_SUFFIX)
+export CPU_TF2_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.7-lightning-1.2-tf-2.4$(CPU_SUFFIX)
+export GPU_TF2_ENVIRONMENT_NAME := $(CUDA_101_PREFIX)pytorch-1.7-lightning-1.2-tf-2.4$(GPU_SUFFIX)
 
 export CUDA_11_NVIDIA_TF_ENVIRONMENT_NAME := $(CUDA_110_PREFIX)pytorch-1.7-tf-1.15$(GPU_SUFFIX)
-export CUDA_11_ENVIRONMENT_NAME := $(CUDA_110_PREFIX)pytorch-1.7-tf-2.4$(GPU_SUFFIX)
+export CUDA_11_ENVIRONMENT_NAME := $(CUDA_110_PREFIX)pytorch-1.7-lightning-1.2-tf-2.4$(GPU_SUFFIX)
 
 # Timeout used by packer for AWS operations. Default is 120 (30 minutes) for
 # waiting for AMI availablity. Bump to 360 attempts = 90 minutes.

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ build-tf1-cpu:
 	docker build -f Dockerfile.cpu \
 		--build-arg TENSORFLOW_PIP="tensorflow==1.15.5" \
 		--build-arg TORCH_PIP="torch==1.7.1" \
+		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2" \
 		--build-arg TENSORPACK_PIP="git+https://github.com/determined-ai/tensorpack.git@0cb4fe8e6e9b7de861c9a1e0d48ffff72b72138a" \
 		-t $(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
@@ -37,6 +38,7 @@ build-tf2-cpu:
 	docker build -f Dockerfile.cpu \
 		--build-arg TENSORFLOW_PIP="tensorflow==2.4.1" \
 		--build-arg TORCH_PIP="torch==1.7.1" \
+		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2" \
 		-t $(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
 		-t $(CPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
@@ -48,6 +50,7 @@ build-tf1-gpu:
 		--build-arg BASE_IMAGE="nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04" \
 		--build-arg TENSORFLOW_PIP="tensorflow-gpu==1.15.5" \
 		--build-arg TORCH_PIP="torch==1.7.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
+		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5" \
 		--build-arg APEX_GIT="https://github.com/determined-ai/apex.git@37cdaf4ad57ab4e7dd9ef13dbed7b29aa939d061" \
@@ -64,6 +67,7 @@ build-tf2-gpu:
 		--build-arg BASE_IMAGE="nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04" \
 		--build-arg TENSORFLOW_PIP="tensorflow==2.4.1" \
 		--build-arg TORCH_PIP="torch==1.7.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
+		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5" \
 		--build-arg APEX_GIT="https://github.com/determined-ai/apex.git@37cdaf4ad57ab4e7dd9ef13dbed7b29aa939d061" \
@@ -79,6 +83,7 @@ build-cuda-11:
 		--build-arg BASE_IMAGE="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04" \
 		--build-arg TENSORFLOW_PIP="tensorflow==2.4.1" \
 		--build-arg TORCH_PIP="torch==1.7.1+cu110 -f https://download.pytorch.org/whl/torch_stable.html" \
+		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2+cu110  -f https://download.pytorch.org/whl/torch_stable.html" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5;8.0" \
 		--build-arg APEX_GIT="https://github.com/NVIDIA/apex.git@154c6336aa7aedd40d3b3583fb5e1328f9cdf387" \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ build-tf1-cpu:
 	docker build -f Dockerfile.cpu \
 		--build-arg TENSORFLOW_PIP="tensorflow==1.15.5" \
 		--build-arg TORCH_PIP="torch==1.7.1" \
-		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2" \
 		--build-arg TENSORPACK_PIP="git+https://github.com/determined-ai/tensorpack.git@0cb4fe8e6e9b7de861c9a1e0d48ffff72b72138a" \
 		-t $(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
@@ -50,7 +49,6 @@ build-tf1-gpu:
 		--build-arg BASE_IMAGE="nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04" \
 		--build-arg TENSORFLOW_PIP="tensorflow-gpu==1.15.5" \
 		--build-arg TORCH_PIP="torch==1.7.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
-		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5" \
 		--build-arg APEX_GIT="https://github.com/determined-ai/apex.git@37cdaf4ad57ab4e7dd9ef13dbed7b29aa939d061" \


### PR DESCRIPTION
with pytorch_lightning `determinedai/environments                       cuda-11.0-pytorch-1.7-tf-2.4-gpu-0.9.0      bd4b268027b4   2 hours ago     13.6GB`

without pytorch_lightning `determinedai/environments                       cuda-11.0-pytorch-1.7-tf-2.4-gpu-83fb707    bff7363d121c   5 minutes ago   13.5GB`

I tested by building the above image and using it to run a pytorch_lightning experiment