### PR TITLE
Revert "ci: push docker images to the NGC registry (#66)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,17 +5,9 @@ orbs:
   gcp-cli: circleci/gcp-cli@1.8.4
 
 commands:
-  login-docker:
-    parameters:
-      repository:
-        type: string
-        default: ""
-      username:
-        type: string
-      password:
-        type: string
+  docker-login:
     steps:
-      - run: echo "<<parameters.password>>" | docker login <<parameters.repository>> -u "<<parameters.username>>" --password-stdin
+      - run: echo "${DOCKER_PASS}" | docker login --username ${DOCKER_USER} --password-stdin
   activate-service-account:
     steps:
       - run:
@@ -66,13 +58,7 @@ jobs:
     steps:
       - checkout
       - install-docker
-      - login-docker:
-          username: ${DOCKER_USER}
-          password: ${DOCKER_PASS}
-      - login-docker:
-          repository: nvcr.io
-          username: ${NGC_API_USERNAME}
-          password: ${NGC_API_KEY}
+      - docker-login
       - run: make build-<<parameters.image-type>>
       - run: make publish-<<parameters.image-type>>
       - store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,10 @@ VERSION := $(shell cat VERSION)
 VERSION_DASHES := $(subst .,-,$(VERSION))
 SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 
-NGC_REGISTRY := nvcr.io/isv-ngc-partner/determined
-DOCKERHUB_REGISTRY := determinedai
-
-CPU_PREFIX := environments:py-3.6.9-
+CPU_PREFIX := determinedai/environments:py-3.6.9-
 CPU_SUFFIX := -cpu
-CUDA_101_PREFIX := environments:cuda-10.1-
-CUDA_110_PREFIX := environments:cuda-11.0-
+CUDA_101_PREFIX := determinedai/environments:cuda-10.1-
+CUDA_110_PREFIX := determinedai/environments:cuda-11.0-
 GPU_SUFFIX := -gpu
 ARTIFACTS_DIR := /tmp/artifacts
 
@@ -31,10 +28,8 @@ build-tf1-cpu:
 		--build-arg TORCH_PIP="torch==1.7.1" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2" \
 		--build-arg TENSORPACK_PIP="git+https://github.com/determined-ai/tensorpack.git@0cb4fe8e6e9b7de861c9a1e0d48ffff72b72138a" \
-		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
-		-t $(NGC_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(NGC_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
+		-t $(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(CPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
 		.
 
 .PHONY: build-tf2-cpu
@@ -44,10 +39,8 @@ build-tf2-cpu:
 		--build-arg TORCH_PIP="torch==1.7.1" \
 		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2" \
-		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
-		-t $(NGC_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(NGC_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
+		-t $(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(CPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
 		.
 
 .PHONY: build-tf1-gpu
@@ -62,10 +55,8 @@ build-tf1-gpu:
 		--build-arg TENSORPACK_PIP="git+https://github.com/determined-ai/tensorpack.git@0cb4fe8e6e9b7de861c9a1e0d48ffff72b72138a" \
 		--build-arg HOROVOD_WITH_TENSORFLOW="1" \
 		--build-arg HOROVOD_WITH_PYTORCH="1" \
-		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
-		-t $(NGC_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(NGC_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
+		-t $(GPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(GPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
 		.
 
 .PHONY: build-tf2-gpu
@@ -80,10 +71,8 @@ build-tf2-gpu:
 		--build-arg APEX_GIT="https://github.com/determined-ai/apex.git@37cdaf4ad57ab4e7dd9ef13dbed7b29aa939d061" \
 		--build-arg HOROVOD_WITH_TENSORFLOW="1" \
 		--build-arg HOROVOD_WITH_PYTORCH="1" \
-		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
-		-t $(NGC_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(NGC_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
+		-t $(GPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(GPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
 		.
 
 .PHONY: build-cuda-11
@@ -98,36 +87,29 @@ build-cuda-11:
 		--build-arg APEX_GIT="https://github.com/NVIDIA/apex.git@154c6336aa7aedd40d3b3583fb5e1328f9cdf387" \
 		--build-arg HOROVOD_WITH_TENSORFLOW="1" \
 		--build-arg HOROVOD_WITH_PYTORCH="1" \
-		-t $(DOCKERHUB_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(DOCKERHUB_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME)-$(VERSION) \
-		-t $(NGC_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(NGC_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME)-$(VERSION) \
+		-t $(CUDA_11_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(CUDA_11_ENVIRONMENT_NAME)-$(VERSION) \
 		.
 
 .PHONY: publish-tf1-cpu
 publish-tf1-cpu:
-	scripts/publish-docker.sh tf1-cpu $(DOCKERHUB_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh tf1-cpu $(NGC_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh tf1-cpu $(CPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-tf2-cpu
 publish-tf2-cpu:
-	scripts/publish-docker.sh tf2-cpu $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh tf2-cpu $(NGC_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh tf2-cpu $(CPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-tf1-gpu
 publish-tf1-gpu:
-	scripts/publish-docker.sh tf1-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh tf1-gpu $(NGC_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh tf1-gpu $(GPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-tf2-gpu
 publish-tf2-gpu:
-	scripts/publish-docker.sh tf2-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh tf2-gpu $(NGC_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh tf2-gpu $(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-cuda-11
 publish-cuda-11:
-	scripts/publish-docker.sh cuda-11 $(DOCKERHUB_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh cuda-11 $(NGC_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh cuda-11 $(CUDA_11_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-cloud-images
 publish-cloud-images:


### PR DESCRIPTION
This reverts commit 279476f3acbe3cb501fc7b10e3fa4a1a8a8c836c.

Environment builds (and bumpenvs in the main repo) are currently broken. I think we should back out the NGC changes to unblock the release, and add the NGC step back as a separate build step.