### PR TITLE
chore: fix Docker publishing code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION_DASHES := $(subst .,-,$(VERSION))
 SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 
 NGC_REGISTRY := nvcr.io/isv-ngc-partner/determined
-DOCKERHUB_REGISTRY := determinedai
+export DOCKERHUB_REGISTRY := determinedai
 
 CPU_PREFIX := environments:py-3.6.9-
 CPU_SUFFIX := -cpu
@@ -107,27 +107,27 @@ build-cuda-11:
 .PHONY: publish-tf1-cpu
 publish-tf1-cpu:
 	scripts/publish-docker.sh tf1-cpu $(DOCKERHUB_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh tf1-cpu $(NGC_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh tf1-cpu $(NGC_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
 
 .PHONY: publish-tf2-cpu
 publish-tf2-cpu:
 	scripts/publish-docker.sh tf2-cpu $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh tf2-cpu $(NGC_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh tf2-cpu $(NGC_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
 
 .PHONY: publish-tf1-gpu
 publish-tf1-gpu:
 	scripts/publish-docker.sh tf1-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh tf1-gpu $(NGC_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh tf1-gpu $(NGC_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
 
 .PHONY: publish-tf2-gpu
 publish-tf2-gpu:
 	scripts/publish-docker.sh tf2-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh tf2-gpu $(NGC_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh tf2-gpu $(NGC_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
 
 .PHONY: publish-cuda-11
 publish-cuda-11:
 	scripts/publish-docker.sh cuda-11 $(DOCKERHUB_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
-	scripts/publish-docker.sh cuda-11 $(NGC_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh cuda-11 $(NGC_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
 
 .PHONY: publish-cloud-images
 publish-cloud-images:

--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -13,7 +13,8 @@
     "gpu_tf2_environment_name": "{{ env `GPU_TF2_ENVIRONMENT_NAME` }}",
     "cpu_tf2_environment_name": "{{ env `CPU_TF2_ENVIRONMENT_NAME` }}",
     "short_git_hash": "{{ env `short_git_hash` }}",
-    "image_suffix": ""
+    "image_suffix": "",
+    "docker_registry": "{{ env `DOCKERHUB_REGISTRY` }}"
   },
   "provisioners": [
     {
@@ -30,10 +31,10 @@
         "-e ansible_python_interpreter=/usr/bin/python3",
         "-e linux_kernel_suffix=aws",
         "-e build_type={{ build_type }}",
-        "-e gpu_tf1_environment_name={{ user `gpu_tf1_environment_name` }}",
-        "-e cpu_tf1_environment_name={{ user `cpu_tf1_environment_name` }}",
-        "-e gpu_tf2_environment_name={{ user `gpu_tf2_environment_name` }}",
-        "-e cpu_tf2_environment_name={{ user `cpu_tf2_environment_name` }}",
+        "-e gpu_tf1_environment_name={{ user `docker_registry` }}/{{ user `gpu_tf1_environment_name` }}",
+        "-e cpu_tf1_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf1_environment_name` }}",
+        "-e gpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `gpu_tf2_environment_name` }}",
+        "-e cpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf2_environment_name` }}",
         "-e short_git_hash={{ user `short_git_hash` }}",
         "-e image_suffix={{ user `image_suffix` }}"
       ],
@@ -48,10 +49,10 @@
         "-e ansible_python_interpreter=/usr/bin/python3",
         "-e linux_kernel_suffix=gcp",
         "-e build_type={{ build_type }}",
-        "-e gpu_tf1_environment_name={{ user `gpu_tf1_environment_name` }}",
-        "-e cpu_tf1_environment_name={{ user `cpu_tf1_environment_name` }}",
-        "-e gpu_tf2_environment_name={{ user `gpu_tf2_environment_name` }}",
-        "-e cpu_tf2_environment_name={{ user `cpu_tf2_environment_name` }}",
+        "-e gpu_tf1_environment_name={{ user `docker_registry` }}/{{ user `gpu_tf1_environment_name` }}",
+        "-e cpu_tf1_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf1_environment_name` }}",
+        "-e gpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `gpu_tf2_environment_name` }}",
+        "-e cpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf2_environment_name` }}",
         "-e short_git_hash={{ user `short_git_hash` }}",
         "-e image_suffix={{ user `image_suffix` }}"
       ],

--- a/scripts/publish-docker.sh
+++ b/scripts/publish-docker.sh
@@ -19,10 +19,12 @@ underscore_name="$(echo -n "$log_name" | tr - _)"
 docker push "$base_tag-$hash"
 docker push "$base_tag-$version"
 
-mkdir -p "$artifacts"
+if [ -z "$artifacts" ]; then
+    mkdir -p "$artifacts"
 
-log_file="$artifacts/publish-$log_name"
-(
-    echo "${underscore_name}_hashed: $base_tag-$hash"
-    echo "${underscore_name}_versioned: $base_tag-$version"
-) > "$log_file"
+    log_file="$artifacts/publish-$log_name"
+    (
+        echo "${underscore_name}_hashed: $base_tag-$hash"
+        echo "${underscore_name}_versioned: $base_tag-$version"
+    ) > "$log_file"
+fi

--- a/scripts/publish-docker.sh
+++ b/scripts/publish-docker.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-if [ "$#" -ne 5 ] ; then
+if [ "$#" -lt 4 ] || [ "$#" -gt 5 ] ; then
     echo "usage: $0 LOG_NAME BASE_TAG HASH VERSION ARTIFACTS_DIR" >&2
     exit 1
 fi
@@ -19,7 +19,7 @@ underscore_name="$(echo -n "$log_name" | tr - _)"
 docker push "$base_tag-$hash"
 docker push "$base_tag-$version"
 
-if [ -z "$artifacts" ]; then
+if [ -n "$artifacts" ]; then
     mkdir -p "$artifacts"
 
     log_file="$artifacts/publish-$log_name"


### PR DESCRIPTION
* Use the complete DockerHub path when downloading for cloud images
* Only write to artifacts for the DockerHub downloads