### PR TITLE
chore: Run Ansible playbook on both AWS builders

### DIFF
--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -39,7 +39,7 @@
         "-e image_suffix={{ user `image_suffix` }}"
       ],
       "user": "ubuntu",
-      "only": ["amazon-ebs"]
+      "only": ["amazon-ebs", "amazon-ebs-gov"]
     },
     {
       "type": "ansible",


### PR DESCRIPTION
There are 2 Ansible playbook invocations, an AWS-specific one and a GCP-specific one. Right now neither runs for the GovCloud builder - so having the AWS one apply to both.