### PR TITLE
chore: various Python, PyTorch and CUDA upgrades

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -36,7 +36,7 @@ RUN /tmp/det_dockerfile_scripts/install_google_cloud_sdk.sh
 
 ENV PATH="/opt/conda/bin:${PATH}"
 ENV PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1 PYTHONHASHSEED=0
-ARG PYTHON_VERSION=3.6
+ARG PYTHON_VERSION
 RUN /tmp/det_dockerfile_scripts/install_python.sh ${PYTHON_VERSION}
 
 ARG TENSORFLOW_PIP

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -37,7 +37,7 @@ RUN /tmp/det_dockerfile_scripts/install_google_cloud_sdk.sh
 
 ENV PATH="/opt/conda/bin:${PATH}"
 ENV PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1 PYTHONHASHSEED=0
-ARG PYTHON_VERSION=3.6
+ARG PYTHON_VERSION
 RUN /tmp/det_dockerfile_scripts/install_python.sh ${PYTHON_VERSION}
 
 ARG TENSORFLOW_PIP

--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,20 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 NGC_REGISTRY := nvcr.io/isv-ngc-partner/determined
 export DOCKERHUB_REGISTRY := determinedai
 
-CPU_PREFIX := environments:py-3.6.9-
+CPU_PREFIX := environments:py-3.7-
 CPU_SUFFIX := -cpu
-CUDA_101_PREFIX := environments:cuda-10.1-
-CUDA_110_PREFIX := environments:cuda-11.0-
+CUDA_102_PREFIX := environments:cuda-10.2-
+CUDA_111_PREFIX := environments:cuda-11.1-
 GPU_SUFFIX := -gpu
 ARTIFACTS_DIR := /tmp/artifacts
 
-export CPU_TF1_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.7-tf-1.15$(CPU_SUFFIX)
-export GPU_TF1_ENVIRONMENT_NAME := $(CUDA_101_PREFIX)pytorch-1.7-tf-1.15$(GPU_SUFFIX)
-export CPU_TF2_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.7-lightning-1.2-tf-2.4$(CPU_SUFFIX)
-export GPU_TF2_ENVIRONMENT_NAME := $(CUDA_101_PREFIX)pytorch-1.7-lightning-1.2-tf-2.4$(GPU_SUFFIX)
+export CPU_TF1_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.8-tf-1.15$(CPU_SUFFIX)
+export GPU_TF1_ENVIRONMENT_NAME := $(CUDA_102_PREFIX)pytorch-1.8-tf-1.15$(GPU_SUFFIX)
+export CPU_TF2_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.8-lightning-1.2-tf-2.4$(CPU_SUFFIX)
+export GPU_TF2_ENVIRONMENT_NAME := $(CUDA_102_PREFIX)pytorch-1.8-lightning-1.2-tf-2.4$(GPU_SUFFIX)
 
-export CUDA_11_NVIDIA_TF_ENVIRONMENT_NAME := $(CUDA_110_PREFIX)pytorch-1.7-tf-1.15$(GPU_SUFFIX)
-export CUDA_11_ENVIRONMENT_NAME := $(CUDA_110_PREFIX)pytorch-1.7-lightning-1.2-tf-2.4$(GPU_SUFFIX)
+export CUDA_11_NVIDIA_TF_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.8-tf-1.15$(GPU_SUFFIX)
+export CUDA_11_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.8-lightning-1.2-tf-2.4$(GPU_SUFFIX)
 
 # Timeout used by packer for AWS operations. Default is 120 (30 minutes) for
 # waiting for AMI availablity. Bump to 360 attempts = 90 minutes.
@@ -27,9 +27,10 @@ export AWS_MAX_ATTEMPTS=360
 .PHONY: build-tf1-cpu
 build-tf1-cpu:
 	docker build -f Dockerfile.cpu \
+		--build-arg PYTHON_VERSION="3.7" \
 		--build-arg TENSORFLOW_PIP="tensorflow==1.15.5" \
-		--build-arg TORCH_PIP="torch==1.7.1" \
-		--build-arg TORCHVISION_PIP="torchvision==0.8.2" \
+		--build-arg TORCH_PIP="torch==1.8.0 -f https://download.pytorch.org/whl/cpu/torch_stable.html" \
+		--build-arg TORCHVISION_PIP="torchvision==0.8.2 -f https://download.pytorch.org/whl/cpu/torch_stable.html" \
 		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
 		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
 		-t $(NGC_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
@@ -39,10 +40,11 @@ build-tf1-cpu:
 .PHONY: build-tf2-cpu
 build-tf2-cpu:
 	docker build -f Dockerfile.cpu \
+		--build-arg PYTHON_VERSION="3.7" \
 		--build-arg TENSORFLOW_PIP="tensorflow==2.4.1" \
-		--build-arg TORCH_PIP="torch==1.7.1" \
+		--build-arg TORCH_PIP="torch==1.8.0 -f https://download.pytorch.org/whl/cpu/torch_stable.html" \
+		--build-arg TORCHVISION_PIP="torchvision==0.8.2 -f https://download.pytorch.org/whl/cpu/torch_stable.html" \
 		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
-		--build-arg TORCHVISION_PIP="torchvision==0.8.2" \
 		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
 		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
 		-t $(NGC_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
@@ -52,10 +54,11 @@ build-tf2-cpu:
 .PHONY: build-tf1-gpu
 build-tf1-gpu:
 	docker build -f Dockerfile.gpu \
-		--build-arg BASE_IMAGE="nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04" \
+		--build-arg PYTHON_VERSION="3.7" \
+		--build-arg BASE_IMAGE="nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04" \
 		--build-arg TENSORFLOW_PIP="tensorflow-gpu==1.15.5" \
-		--build-arg TORCH_PIP="torch==1.7.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
-		--build-arg TORCHVISION_PIP="torchvision==0.8.2+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
+		--build-arg TORCH_PIP="torch==1.8.0 -f https://download.pytorch.org/whl/cu102/torch_stable.html" \
+		--build-arg TORCHVISION_PIP="torchvision==0.9.0 -f https://download.pytorch.org/whl/cu102/torch_stable.html" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5" \
 		--build-arg APEX_GIT="https://github.com/determined-ai/apex.git@37cdaf4ad57ab4e7dd9ef13dbed7b29aa939d061" \
 		--build-arg HOROVOD_WITH_TENSORFLOW="1" \
@@ -69,11 +72,12 @@ build-tf1-gpu:
 .PHONY: build-tf2-gpu
 build-tf2-gpu:
 	docker build -f Dockerfile.gpu \
-		--build-arg BASE_IMAGE="nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04" \
+		--build-arg PYTHON_VERSION="3.7" \
+		--build-arg BASE_IMAGE="nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04" \
 		--build-arg TENSORFLOW_PIP="tensorflow==2.4.1" \
-		--build-arg TORCH_PIP="torch==1.7.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
+		--build-arg TORCH_PIP="torch==1.8.0 -f https://download.pytorch.org/whl/cu102/torch_stable.html" \
+		--build-arg TORCHVISION_PIP="torchvision==0.9.0 -f https://download.pytorch.org/whl/cu102/torch_stable.html" \
 		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
-		--build-arg TORCHVISION_PIP="torchvision==0.8.2+cu101 -f https://download.pytorch.org/whl/torch_stable.html" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5" \
 		--build-arg APEX_GIT="https://github.com/determined-ai/apex.git@37cdaf4ad57ab4e7dd9ef13dbed7b29aa939d061" \
 		--build-arg HOROVOD_WITH_TENSORFLOW="1" \
@@ -87,11 +91,12 @@ build-tf2-gpu:
 .PHONY: build-cuda-11
 build-cuda-11:
 	docker build -f Dockerfile.gpu \
-		--build-arg BASE_IMAGE="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04" \
+		--build-arg PYTHON_VERSION="3.8" \
+		--build-arg BASE_IMAGE="nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04" \
 		--build-arg TENSORFLOW_PIP="tensorflow==2.4.1" \
-		--build-arg TORCH_PIP="torch==1.7.1+cu110 -f https://download.pytorch.org/whl/torch_stable.html" \
+		--build-arg TORCH_PIP="torch==1.8.0 -f https://download.pytorch.org/whl/cu111/torch_stable.html" \
+		--build-arg TORCHVISION_PIP="torchvision==0.9.0 -f https://download.pytorch.org/whl/cu111/torch_stable.html" \
 		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
-		--build-arg TORCHVISION_PIP="torchvision==0.8.2+cu110  -f https://download.pytorch.org/whl/torch_stable.html" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5;8.0" \
 		--build-arg APEX_GIT="https://github.com/NVIDIA/apex.git@154c6336aa7aedd40d3b3583fb5e1328f9cdf387" \
 		--build-arg HOROVOD_WITH_TENSORFLOW="1" \

--- a/cloud/roles/nvidia-drivers/defaults/main.yml
+++ b/cloud/roles/nvidia-drivers/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # NVIDIA Driver Settings
-driver_version: "450.51.05"
+driver_version: "460.56"
 driver_script_name: "NVIDIA-Linux-x86_64-{{ driver_version }}.run"
-driver_url: "https://us.download.nvidia.com/tesla/{{ driver_version }}/{{ driver_script_name }}"
+driver_url: "https://us.download.nvidia.com/XFree86/Linux-x86_64/{{ driver_version }}/{{ driver_script_name }}"


### PR DESCRIPTION
A bunch of version updates that were requested, including base CUDA versions, driver versions, Python versions, PyTorch versions, etc. 

This includes a switch to how we use PyTorch's package indexes, as described here: https://github.com/pytorch/pytorch/issues/53821

I set these images as the default for end to end tests as a functionality and performance check: 
https://app.circleci.com/pipelines/github/determined-ai/determined?branch=mackrory. The most recent run is the current state. The previous run is with these images. Performance is slightly worse overall but to upgrade we just have to bite the bullet on that. When I last dug into this, some models performed better, some models performed worse. The old images will still be available for some time and we'll just need to document that change and potential implications.