### PR TITLE
fix: pre-load CUDA 11 environment into cloud images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ export CPU_TF1_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.8-tf-1.15$(CPU_SUFFIX)
 export GPU_TF1_ENVIRONMENT_NAME := $(CUDA_102_PREFIX)pytorch-1.8-tf-1.15$(GPU_SUFFIX)
 export CPU_TF2_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.8-lightning-1.2-tf-2.4$(CPU_SUFFIX)
 export GPU_TF2_ENVIRONMENT_NAME := $(CUDA_102_PREFIX)pytorch-1.8-lightning-1.2-tf-2.4$(GPU_SUFFIX)
-
-export CUDA_11_NVIDIA_TF_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.8-tf-1.15$(GPU_SUFFIX)
 export CUDA_11_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.8-lightning-1.2-tf-2.4$(GPU_SUFFIX)
 
 # Timeout used by packer for AWS operations. Default is 120 (30 minutes) for

--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -12,6 +12,7 @@
     "cpu_tf1_environment_name": "{{ env `CPU_TF1_ENVIRONMENT_NAME` }}",
     "gpu_tf2_environment_name": "{{ env `GPU_TF2_ENVIRONMENT_NAME` }}",
     "cpu_tf2_environment_name": "{{ env `CPU_TF2_ENVIRONMENT_NAME` }}",
+    "cuda_11_environment_name": "{{ env `CUDA_11_ENVIRONMENT_NAME` }}",
     "short_git_hash": "{{ env `short_git_hash` }}",
     "image_suffix": "",
     "docker_registry": "{{ env `DOCKERHUB_REGISTRY` }}"
@@ -35,6 +36,7 @@
         "-e cpu_tf1_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf1_environment_name` }}",
         "-e gpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `gpu_tf2_environment_name` }}",
         "-e cpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf2_environment_name` }}",
+        "-e cuda_11_environment_name={{ user `docker_registry` }}/{{ user `cuda_11_environment_name` }}",
         "-e short_git_hash={{ user `short_git_hash` }}",
         "-e image_suffix={{ user `image_suffix` }}"
       ],
@@ -53,6 +55,7 @@
         "-e cpu_tf1_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf1_environment_name` }}",
         "-e gpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `gpu_tf2_environment_name` }}",
         "-e cpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf2_environment_name` }}",
+        "-e cuda_11_environment_name={{ user `docker_registry` }}/{{ user `cuda_11_environment_name` }}",
         "-e short_git_hash={{ user `short_git_hash` }}",
         "-e image_suffix={{ user `image_suffix` }}"
       ],

--- a/cloud/roles/environments/tasks/main.yml
+++ b/cloud/roles/environments/tasks/main.yml
@@ -42,3 +42,9 @@
   docker_image:
     name: "{{ cpu_tf2_environment_name }}{{ image_suffix }}"
     source: pull
+
+- name: Pull CUDA 11 environment
+  become: yes
+  docker_image:
+    name: "{{ cuda_11_environment_name }}{{ image_suffix }}"
+    source: pull


### PR DESCRIPTION
This step was missed previously. Also, removing a reference to the other CUDA 11 image that's not actually ready.