### PR TITLE
chore: switch to Ubuntu 20.04 repositories and Python 3

### DIFF
--- a/cloud/roles/gpumon/files/gpumon
+++ b/cloud/roles/gpumon/files/gpumon
@@ -4,7 +4,7 @@ import argparse
 import boto3
 import os
 import subprocess
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 # Storage resolution (between 1-60). 60 is for a low-resolution metric, which
 # is stored per minute.
@@ -12,10 +12,10 @@ RESOLUTION = 60
 
 # Instance information
 BASE_URL = "http://169.254.169.254/latest/meta-data/"
-INSTANCE_ID = urllib2.urlopen(BASE_URL + "instance-id").read()
-IMAGE_ID = urllib2.urlopen(BASE_URL + "ami-id").read()
-INSTANCE_TYPE = urllib2.urlopen(BASE_URL + "instance-type").read()
-INSTANCE_AZ = urllib2.urlopen(BASE_URL + "placement/availability-zone").read()
+INSTANCE_ID = urllib.request.urlopen(BASE_URL + "instance-id").read()
+IMAGE_ID = urllib.request.urlopen(BASE_URL + "ami-id").read()
+INSTANCE_TYPE = urllib.request.urlopen(BASE_URL + "instance-type").read()
+INSTANCE_AZ = urllib.request.urlopen(BASE_URL + "placement/availability-zone").read()
 EC2_REGION = INSTANCE_AZ[:-1]
 
 

--- a/cloud/roles/gpumon/tasks/main.yml
+++ b/cloud/roles/gpumon/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: Install boto3 for Python2.
+- name: Install boto3 for Python.
   become: yes
   apt:
     name:
-    - python-boto3
+    - python3-boto3
     state: present
 
 - name: Install gpumon.

--- a/cloud/roles/nvidia-docker/tasks/main.yml
+++ b/cloud/roles/nvidia-docker/tasks/main.yml
@@ -14,9 +14,9 @@
     state: present
     update_cache: yes
   with_items:
-    - deb https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64 /
-    - deb https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64 /
-    - deb https://nvidia.github.io/nvidia-docker/ubuntu16.04/amd64 /
+    - deb https://nvidia.github.io/libnvidia-container/ubuntu20.04/amd64 /
+    - deb https://nvidia.github.io/nvidia-container-runtime/ubuntu20.04/amd64 /
+    - deb https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64 /
 
 - name: Install Nvidia Docker Runtime.
   become: yes


### PR DESCRIPTION
Confirmed the new repository URLs on NVIDIA's site, confirmed the new package name on my local Ubuntu 12.04 system, and confirmed the modified gpumon script at least parses correctly in Python 3.7.