### PR TITLE
feat: add horovod to CPU images.

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -48,6 +48,14 @@ RUN if [ "$TORCH_PIP" ]; then pip install $TORCH_PIP; fi
 RUN if [ "$TORCHVISION_PIP" ]; then pip install $TORCHVISION_PIP; fi
 RUN if [ "$LIGHTNING_PIP" ]; then pip install $LIGHTNING_PIP; fi
 
+ARG HOROVOD_PIP=horovod
+ARG HOROVOD_WITH_TENSORFLOW=1
+ARG HOROVOD_WITH_PYTORCH=1
+ARG HOROVOD_WITHOUT_MXNET=1
+ARG HOROVOD_WITHOUT_MPI=1
+ARG HOROVOD_CPU_OPERATIONS=GLOO
+RUN pip install "$HOROVOD_PIP"
+
 # We uninstall these packages after installing. This ensures that we can
 # successfully install these packages into containers running as non-root.
 # `pip` does not uninstall dependencies, so we still have all the dependencies

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build-tf1-cpu:
 		--build-arg TENSORFLOW_PIP="tensorflow==1.15.5" \
 		--build-arg TORCH_PIP="torch==1.7.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2 -f https://download.pytorch.org/whl/cpu/torch_stable.html" \
+		--build-arg HOROVOD_PIP="horovod==0.22.0" \
 		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
 		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
 		-t $(NGC_REGISTRY)/$(CPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
@@ -42,6 +43,7 @@ build-tf2-cpu:
 		--build-arg TORCH_PIP="torch==1.7.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html" \
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2 -f https://download.pytorch.org/whl/cpu/torch_stable.html" \
 		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
+		--build-arg HOROVOD_PIP="horovod==0.22.0" \
 		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
 		-t $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
 		-t $(NGC_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
@@ -58,8 +60,6 @@ build-tf1-gpu:
 		--build-arg TORCHVISION_PIP="torchvision==0.8.2 -f https://download.pytorch.org/whl/cu102/torch_stable.html" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5" \
 		--build-arg APEX_GIT="https://github.com/NVIDIA/apex.git@b5eb38dbf7accc24bd872b3ab67ffc77ee858e62" \
-		--build-arg HOROVOD_WITH_TENSORFLOW="1" \
-		--build-arg HOROVOD_WITH_PYTORCH="1" \
 		--build-arg HOROVOD_PIP="horovod==0.22.0" \
 		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
 		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF1_ENVIRONMENT_NAME)-$(VERSION) \
@@ -78,8 +78,6 @@ build-cuda-11:
 		--build-arg LIGHTNING_PIP="pytorch_lightning==1.2.0" \
 		--build-arg TORCH_CUDA_ARCH_LIST="3.7;6.0;6.1;6.2;7.0;7.5;8.0" \
 		--build-arg APEX_GIT="https://github.com/NVIDIA/apex.git@b5eb38dbf7accc24bd872b3ab67ffc77ee858e62" \
-		--build-arg HOROVOD_WITH_TENSORFLOW="1" \
-		--build-arg HOROVOD_WITH_PYTORCH="1" \
 		--build-arg HOROVOD_PIP="horovod==0.22.0" \
 		-t $(DOCKERHUB_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
 		-t $(DOCKERHUB_REGISTRY)/$(CUDA_11_ENVIRONMENT_NAME)-$(VERSION) \


### PR DESCRIPTION
This is a part of the upcoming CPU-only distributed training feature. It adds about 20M to the image size.
Also, remove redundant `HOROVOD_WITH_TENSORFLOW` and `HOROVOD_WITH_PYTORCH` arguments on the GPU images, as these are default values anyway.
Intended to be landed after https://github.com/determined-ai/environments/pull/94