### PR TITLE
fix: always apply security upgrades to base images.

### DIFF
--- a/Dockerfile-base-cpu
+++ b/Dockerfile-base-cpu
@@ -26,6 +26,8 @@ RUN apt-get update \
 		openssh-server \
 		pkg-config \
 		wget \
+		unattended-upgrades \
+	&& unattended-upgrade \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm /etc/ssh/ssh_host_ecdsa_key \
 	&& rm /etc/ssh/ssh_host_ed25519_key \

--- a/Dockerfile-base-gpu
+++ b/Dockerfile-base-gpu
@@ -26,6 +26,8 @@ RUN apt-get update \
 		openssh-server \
 		pkg-config \
 		wget \
+		unattended-upgrades \
+	&& unattended-upgrade \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm /etc/ssh/ssh_host_ecdsa_key \
 	&& rm /etc/ssh/ssh_host_ed25519_key \


### PR DESCRIPTION
## Description
Nvidia NGC wants our images to have no high severity vulnerabilities. We are currently exposed to https://ubuntu.com/security/CVE-2021-3449
Let's automatically run security upgrades only (via `unattended-upgrades`). These are supposed to be low-risk upgrades.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
