### PR TITLE
feat: run `packer build -force` in CI to allow reruns on failures.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - install-ansible
       - run:
           no_output_timeout: 90m
-          command: make publish-cloud-images
+          command: make publish-cloud-images PACKER_FLAGS="-force"
       - store_artifacts:
           path: /tmp/artifacts
 

--- a/Makefile
+++ b/Makefile
@@ -256,5 +256,5 @@ publish-tf26-gpu:
 publish-cloud-images:
 	mkdir -p $(ARTIFACTS_DIR)
 	cd cloud \
-		&& packer build -machine-readable -var "image_suffix=-$(SHORT_GIT_HASH)" environments-packer.json \
+		&& packer build $(PACKER_FLAGS) -machine-readable -var "image_suffix=-$(SHORT_GIT_HASH)" environments-packer.json \
 		| tee $(ARTIFACTS_DIR)/packer-log


### PR DESCRIPTION
## Description

Packer fails from time to time, and rerunning CircleCI job *does not work* because there're artifacts from the previous run. `-force` can override that. As usual, we've got to use it with care and not rerun published builds.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
