### PR TITLE
chore: replace nvidia-docker runtime with nvidia-container-toolkit [DET-5888]

### DIFF
--- a/cloud/environments-playbook.yml
+++ b/cloud/environments-playbook.yml
@@ -6,7 +6,7 @@
     - { role: utilities, tags: "utilities" }
     - { role: nvidia-drivers, tags: "nvidia-drivers" }
     - { role: docker, tags: "docker" }
-    - { role: nvidia-docker, tags: "nvidia-docker" }
+    - { role: nvidia-container-toolkit, tags: "docker" }
     - { role: journald-cloudwatch, tags: "journald-cloudwatch", when: "build_type == 'amazon-ebs'"}
     - { role: gpumon, tags: "gpumon", when: "build_type == 'amazon-ebs'"}
-    - { role: environments, tags: "nvidia-docker" }
+    - { role: environments, tags: "docker" }

--- a/cloud/roles/nvidia-container-toolkit/tasks/main.yml
+++ b/cloud/roles/nvidia-container-toolkit/tasks/main.yml
@@ -18,21 +18,8 @@
     - deb https://nvidia.github.io/nvidia-container-runtime/ubuntu20.04/amd64 /
     - deb https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64 /
 
-- name: Install Nvidia Docker Runtime.
+- name: Install Nvidia Container Toolkit..
   become: yes
   apt:
-    name: nvidia-docker2
+    name: nvidia-container-toolkit
     state: present
-
-- name: Update Docker daemon configuration.
-  become: yes
-  template:
-    src: daemon.json
-    dest: /etc/docker/daemon.json
-
-- name: Ensure Docker daemon is restarted and enabled.
-  become: yes
-  systemd:
-    name: docker
-    state: restarted
-    enabled: yes

--- a/cloud/roles/nvidia-docker/defaults/main.yml
+++ b/cloud/roles/nvidia-docker/defaults/main.yml
@@ -1,3 +1,0 @@
----
-# Nvidia Settings
-docker_default_runtime: nvidia

--- a/cloud/roles/nvidia-docker/templates/daemon.json
+++ b/cloud/roles/nvidia-docker/templates/daemon.json
@@ -1,9 +1,0 @@
-{
-    "default-runtime": "{{ docker_default_runtime }}",
-    "runtimes": {
-        "nvidia": {
-            "path": "/usr/bin/nvidia-container-runtime",
-            "runtimeArgs": [ ]
-        }
-    }
-}


### PR DESCRIPTION
## Description

We're on a recent enough version of Docker that the old way of overriding the default runtime entirely is unnecessary.

## Testing

I created the AMI locally, configured an Amazon det-deploy cluster to use it as the agent image, and confirmed that GPU containers could be launched.

Before merging I need to go track down a hack that was made necessary by the use of nvidia-docker and see if it can be removed now.

