### PR TITLE
feat: add deepspeed docker env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,8 @@ workflows:
                 - tf26-gpu
                 - tf27-gpu
                 - pytorch19-tf25-rocm
+                - deepspeed-gpu
+                - deeperspeed-gpu
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ workflows:
                 - tf27-gpu
                 - pytorch19-tf25-rocm
                 - deepspeed-gpu
-                - deeperspeed-gpu
+                - gpt-neox-deepspeed-gpu
           filters:
             branches:
               only: master

--- a/Dockerfile-default-gpu
+++ b/Dockerfile-default-gpu
@@ -44,6 +44,6 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN python -m pip install -r /tmp/det_dockerfile_scripts/additional-requirements.txt
 
 ARG DEEPSPEED_PIP
-RUN /tmp/det_dockerfile_scripts/install_deepspeed.sh
+RUN if [ -n "$DEEPSPEED_PIP" ]; then /tmp/det_dockerfile_scripts/install_deepspeed.sh; fi
 
 RUN rm -r /tmp/*

--- a/Dockerfile-default-gpu
+++ b/Dockerfile-default-gpu
@@ -43,4 +43,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 
 RUN python -m pip install -r /tmp/det_dockerfile_scripts/additional-requirements.txt
 
+ARG DEEPSPEED_PIP
+RUN /tmp/det_dockerfile_scripts/install_deepspeed.sh
+
 RUN rm -r /tmp/*

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ export CPU_TF1_ENVIRONMENT_NAME := $(CPU_PREFIX_37)pytorch-1.7-tf-1.15$(CPU_SUFF
 export GPU_TF1_ENVIRONMENT_NAME := $(CUDA_102_PREFIX)pytorch-1.7-tf-1.15$(GPU_SUFFIX)
 export CPU_TF2_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.9-lightning-1.3-tf-2.4$(CPU_SUFFIX)
 export GPU_TF2_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.9-lightning-1.3-tf-2.4$(GPU_SUFFIX)
+export GPU_DEEPSPEED_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.9-lightning-1.3-tf-2.4-deepspeed-0.5.10$(GPU_SUFFIX)
 export CPU_TF25_ENVIRONMENT_NAME := $(CPU_PREFIX)tf-2.5$(CPU_SUFFIX)
 export GPU_TF25_ENVIRONMENT_NAME := $(CUDA_112_PREFIX)tf-2.5$(GPU_SUFFIX)
 export CPU_TF26_ENVIRONMENT_NAME := $(CPU_PREFIX)tf-2.6$(CPU_SUFFIX)
@@ -132,6 +133,36 @@ build-tf2-gpu:
 		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
 		-t $(NGC_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
 		-t $(NGC_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME)-$(VERSION) \
+		.
+
+.PHONY: build-deepspeed-gpu
+build-deepspeed-gpu:
+	# Same base image is used for deepspeed as that for the tf2-gpu image.
+	docker build -f Dockerfile-base-gpu \
+		--build-arg BASE_IMAGE="nvidia/cuda:11.1-cudnn8-devel-ubuntu18.04" \
+		--build-arg PYTHON_VERSION="$(PYTHON_VERSION)" \
+		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF2_BASE_NAME)-$(SHORT_GIT_HASH) \
+		-t $(DOCKERHUB_REGISTRY)/$(GPU_TF2_BASE_NAME)-$(VERSION) \
+		.
+	# We should consider building without tensorflow in the future.  Going to keep tensorflow for
+	# now since we want to have tensorboard support.  It should be possible to install tensorboard
+	# without tensorflow though.
+	docker build -f Dockerfile-default-gpu \
+		--build-arg BASE_IMAGE="$(DOCKERHUB_REGISTRY)/$(GPU_TF2_BASE_NAME)-$(SHORT_GIT_HASH)" \
+		--build-arg TF_CUDA_SYM="1" \
+		--build-arg TENSORFLOW_PIP="tensorflow==2.4.4" \
+		--build-arg TORCH_PIP="torch==1.9.0 -f https://download.pytorch.org/whl/cu111/torch_stable.html" \
+		--build-arg TORCHVISION_PIP="torchvision==0.10.0 -f https://download.pytorch.org/whl/cu111/torch_stable.html" \
+		--build-arg LIGHTNING_PIP="pytorch_lightning==1.3.5 torchmetrics==0.5.1" \
+		--build-arg TORCH_PROFILER_GIT="https://github.com/pytorch/kineto.git@7455c31a01dd98bd0a863feacac4d46c7a44ea40" \
+		--build-arg TORCH_CUDA_ARCH_LIST="6.0;6.1;6.2;7.0;7.5;8.0" \
+		--build-arg APEX_GIT="https://github.com/NVIDIA/apex.git@b5eb38dbf7accc24bd872b3ab67ffc77ee858e62" \
+		--build-arg HOROVOD_PIP="horovod==0.23.0" \
+		--build-arg DEEPSPEED_PIP="deepspeed==0.5.10" \
+		-t $(DOCKERHUB_REGISTRY)/$(GPU_DEEPSPEED_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(DOCKERHUB_REGISTRY)/$(GPU_DEEPSPEED_ENVIRONMENT_NAME)-$(VERSION) \
+		-t $(NGC_REGISTRY)/$(GPU_DEEPSPEED_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(NGC_REGISTRY)/$(GPU_DEEPSPEED_ENVIRONMENT_NAME)-$(VERSION) \
 		.
 
 # TF 2.5 and TF 2.6 images do not have pytorch because their CUDA version doesn't work well with pytorch 1.9.
@@ -284,6 +315,12 @@ publish-tf2-gpu:
 	scripts/publish-docker.sh tf2-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF2_BASE_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 	scripts/publish-docker.sh tf2-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 	scripts/publish-docker.sh tf2-gpu $(NGC_REGISTRY)/$(GPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
+
+.PHONY: publish-deepspeed-gpu
+publish-deepspeed-gpu:
+	scripts/publish-docker.sh deepspeed-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF2_BASE_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh deepspeed-gpu $(DOCKERHUB_REGISTRY)/$(GPU_DEEPSPEED_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh deepspeed-gpu $(NGC_REGISTRY)/$(GPU_DEEPSPEED_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
 
 .PHONY: publish-tf25-cpu
 publish-tf25-cpu:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ export GPU_TF1_ENVIRONMENT_NAME := $(CUDA_102_PREFIX)pytorch-1.7-tf-1.15$(GPU_SU
 export CPU_TF2_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-1.9-lightning-1.3-tf-2.4$(CPU_SUFFIX)
 export GPU_TF2_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.9-lightning-1.3-tf-2.4$(GPU_SUFFIX)
 export GPU_DEEPSPEED_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.9-lightning-1.3-tf-2.4-deepspeed-0.5.10$(GPU_SUFFIX)
-export GPU_DEEPERSPEED_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.9-lightning-1.3-tf-2.4-deeperspeed$(GPU_SUFFIX)
+export GPU_GPT_NEOX_DEEPSPEED_ENVIRONMENT_NAME := $(CUDA_111_PREFIX)pytorch-1.9-lightning-1.3-tf-2.4-gpt-neox-deepspeed$(GPU_SUFFIX)
 export CPU_TF25_ENVIRONMENT_NAME := $(CPU_PREFIX)tf-2.5$(CPU_SUFFIX)
 export GPU_TF25_ENVIRONMENT_NAME := $(CUDA_112_PREFIX)tf-2.5$(GPU_SUFFIX)
 export CPU_TF26_ENVIRONMENT_NAME := $(CPU_PREFIX)tf-2.6$(CPU_SUFFIX)
@@ -169,8 +169,8 @@ build-deepspeed-gpu:
 
 # This builds deepspeed environment off of a patched version of EleutherAI's fork of DeepSpeed 
 # that we need for gpt-neox support.
-.PHONY: build-deeperspeed-gpu
-build-deeperspeed-gpu:
+.PHONY: build-gpt-neox-deepspeed-gpu
+build-gpt-neox-deepspeed-gpu:
 	# Same base image is used for deepspeed as that for the tf2-gpu image.
 	docker build -f Dockerfile-base-gpu \
 		--build-arg BASE_IMAGE="nvidia/cuda:11.1-cudnn8-devel-ubuntu18.04" \
@@ -193,10 +193,10 @@ build-deeperspeed-gpu:
 		--build-arg APEX_GIT="https://github.com/NVIDIA/apex.git@b5eb38dbf7accc24bd872b3ab67ffc77ee858e62" \
 		--build-arg HOROVOD_PIP="horovod==0.23.0" \
 		--build-arg DEEPSPEED_PIP="git+git://github.com/determined-ai/deepspeed.git@eleuther_dai" \
-		-t $(DOCKERHUB_REGISTRY)/$(GPU_DEEPERSPEED_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(DOCKERHUB_REGISTRY)/$(GPU_DEEPERSPEED_ENVIRONMENT_NAME)-$(VERSION) \
-		-t $(NGC_REGISTRY)/$(GPU_DEEPERSPEED_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
-		-t $(NGC_REGISTRY)/$(GPU_DEEPERSPEED_ENVIRONMENT_NAME)-$(VERSION) \
+		-t $(DOCKERHUB_REGISTRY)/$(GPU_GPT_NEOX_DEEPSPEED_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(DOCKERHUB_REGISTRY)/$(GPU_GPT_NEOX_DEEPSPEED_ENVIRONMENT_NAME)-$(VERSION) \
+		-t $(NGC_REGISTRY)/$(GPU_GPT_NEOX_DEEPSPEED_ENVIRONMENT_NAME)-$(SHORT_GIT_HASH) \
+		-t $(NGC_REGISTRY)/$(GPU_GPT_NEOX_DEEPSPEED_ENVIRONMENT_NAME)-$(VERSION) \
 		.
 
 # TF 2.5 and TF 2.6 images do not have pytorch because their CUDA version doesn't work well with pytorch 1.9.
@@ -355,6 +355,12 @@ publish-deepspeed-gpu:
 	scripts/publish-docker.sh deepspeed-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF2_BASE_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 	scripts/publish-docker.sh deepspeed-gpu $(DOCKERHUB_REGISTRY)/$(GPU_DEEPSPEED_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 	scripts/publish-docker.sh deepspeed-gpu $(NGC_REGISTRY)/$(GPU_DEEPSPEED_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
+
+.PHONY: publish-gpt-neox-deepspeed-gpu
+publish-deepspeed-gpu:
+	scripts/publish-docker.sh gpt-neox-deepspeed-gpu $(DOCKERHUB_REGISTRY)/$(GPU_TF2_BASE_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh gpt-neox-deepspeed-gpu $(DOCKERHUB_REGISTRY)/$(GPU_GPT_NEOX_DEEPSPEED_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh gpt-neox-deepspeed-gpu $(NGC_REGISTRY)/$(GPU_GPT_NEOX_DEEPSPEED_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION)
 
 .PHONY: publish-tf25-cpu
 publish-tf25-cpu:

--- a/dockerfile_scripts/additional-requirements.txt
+++ b/dockerfile_scripts/additional-requirements.txt
@@ -1,3 +1,4 @@
+attrdict
 pandas
 matplotlib
 tensorflow-datasets==1.3.2

--- a/dockerfile_scripts/install_deepspeed.sh
+++ b/dockerfile_scripts/install_deepspeed.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y pdsh libaio-dev
+if [ "$DEEPSPEED_PIP" ]; then
+    python -m  pip install ninja psutil packaging attrdict
+    DS_BUILD_OPS=1 python -m  pip install $DEEPSPEED_PIP
+fi

--- a/dockerfile_scripts/install_deepspeed.sh
+++ b/dockerfile_scripts/install_deepspeed.sh
@@ -3,7 +3,4 @@
 set -e
 
 DEBIAN_FRONTEND=noninteractive apt-get install -y pdsh libaio-dev
-if [ "$DEEPSPEED_PIP" ]; then
-    python -m  pip install ninja psutil packaging attrdict
-    DS_BUILD_OPS=1 python -m  pip install $DEEPSPEED_PIP
-fi
+DS_BUILD_OPS=1 pip install $DEEPSPEED_PIP


### PR DESCRIPTION
## Description
Adding a deepspeed docker image for our deepspeed support.  I originally wanted to build it into our default tf2 gpu image but deepspeed is not compatible with 3.7 cuda arch.  As part of deepspeed installation, custom ops are prebuilt to reduce overhead for JIT during training.  

## Checklist

- [x] Bump VERSION to make the pushed images are tagged with the right version.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
