### PR TITLE
fix: publish artifacts for multiplatform images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,8 @@ publish-tf24-gpu:
 
 .PHONY: publish-tf2-cpu
 publish-tf2-cpu:
-	echo "Tensorflow 2.8 CPU image is published by buildx"
+	scripts/publish-docker.sh tf2-cpu $(DOCKERHUB_REGISTRY)/$(CPU_PY_38_BASE_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR) --no-push
+	scripts/publish-docker.sh tf2-cpu $(DOCKERHUB_REGISTRY)/$(CPU_TF2_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR) --no-push
 
 .PHONY: publish-tf2-gpu
 publish-tf2-gpu:
@@ -450,7 +451,8 @@ endif
 
 .PHONY: publish-tf27-cpu
 publish-tf27-cpu:
-	echo "Tensorflow 2.7 CPU image is published by buildx"
+	scripts/publish-docker.sh tf27-cpu $(DOCKERHUB_REGISTRY)/$(CPU_PY_38_BASE_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR) --no-push
+	scripts/publish-docker.sh tf27-cpu $(DOCKERHUB_REGISTRY)/$(CPU_TF27_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR) --no-push
 
 .PHONY: publish-tf27-gpu
 publish-tf27-gpu:

--- a/scripts/publish-docker.sh
+++ b/scripts/publish-docker.sh
@@ -3,8 +3,8 @@
 set -e
 set -x
 
-if [ "$#" -lt 4 ] || [ "$#" -gt 5 ] ; then
-    echo "usage: $0 LOG_NAME BASE_TAG HASH VERSION ARTIFACTS_DIR" >&2
+if [ "$#" -lt 4 ] || [ "$#" -gt 6 ] || [ "$#" -eq 6 ] && [ "$6" != "--no-push" ]; then
+    echo "usage: $0 LOG_NAME BASE_TAG HASH VERSION ARTIFACTS_DIR [--no-push]" >&2
     exit 1
 fi
 
@@ -16,8 +16,10 @@ artifacts="$5"
 
 underscore_name="$(echo -n "$log_name" | tr - _)"
 
-docker push "$base_tag-$hash"
-docker push "$base_tag-$version"
+if [ "$#" -lt 6 ] ; then
+    docker push "$base_tag-$hash"
+    docker push "$base_tag-$version"
+fi
 
 if [ -n "$artifacts" ]; then
     mkdir -p "$artifacts"


### PR DESCRIPTION
## Description

bumpenvs relies on artifacts being published for all environment images. The previous change that enabled building multi-platform images for tf2 and tf27 relied on docker buildx to push images to the repository but I forgot to make sure that the corresponding artifacts be published on circleci.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
