### PR TITLE
fix: do not build ROCm without MPI _twice_

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,9 @@ workflows:
                 - pytorch10-tf27-rocm50
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu
+            exclude:
+              - with-mpi: 1
+                image-type: pytorch10-tf27-rocm50
 
       - publish-cloud-images:
           context: determined-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,9 @@ workflows:
                 - pytorch10-tf27-rocm50
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu
+            exclude:
+              - with-mpi: 1
+                image-type: pytorch10-tf27-rocm50
 
       - publish-cloud-images:
           name: publish-cloud-images-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,8 +164,10 @@ workflows:
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu
             exclude:
-              - with-mpi: 1
+              - dev-mode: false
+                with-mpi: 1
                 image-type: pytorch10-tf27-rocm50
+
 
       - publish-cloud-images:
           context: determined-production
@@ -213,7 +215,8 @@ workflows:
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu
             exclude:
-              - with-mpi: 1
+              - dev-mode: true
+                with-mpi: 1
                 image-type: pytorch10-tf27-rocm50
 
       - publish-cloud-images:

--- a/Makefile
+++ b/Makefile
@@ -532,7 +532,7 @@ endif
 
 .PHONY: publish-pytorch10-tf27-rocm50
 publish-pytorch10-tf27-rocm50:
-	scripts/publish-docker.sh pytorch10-tf27-rocm50 $(DOCKERHUB_REGISTRY)/$(ROCM50_TORCH_TF_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
+	scripts/publish-docker.sh pytorch10-tf27-rocm50-$(WITH_MPI) $(DOCKERHUB_REGISTRY)/$(ROCM50_TORCH_TF_ENVIRONMENT_NAME) $(SHORT_GIT_HASH) $(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-cloud-images
 publish-cloud-images:


### PR DESCRIPTION
## Description

We never built ROCm images with MPI (more precisely, including Horovod without MPI). But when MPI/no MPI switch was introduced we kept building and publishing two identical ROCm images, without MPI, with endings "-0" and "-1" (normally `-0` means without MPI). A recent change stopped adding `-0` or `-1` ending to the ROCm image names. This change is to _actually stop building and publishing_ two identical images.

I also propose to restore adding the ending to the ROCm image just to be consistent with the naming of the other images and explicit about the fact that the image we are publishing has Horovod without MPI.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
