### PR TITLE
chore: do not build mpi flavor for deepspeed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,10 +164,12 @@ workflows:
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu
             exclude:
-              - dev-mode: false
-                with-mpi: 1
+              - with-mpi: 1
                 image-type: pytorch10-tf27-rocm50
-
+              - with-mpi: 1
+                image-type: deepspeed-gpu
+              - with-mpi: 1
+                image-type: gpt-neox-deepspeed-gpu
 
       - publish-cloud-images:
           context: determined-production
@@ -218,6 +220,12 @@ workflows:
               - dev-mode: true
                 with-mpi: 1
                 image-type: pytorch10-tf27-rocm50
+              - dev-mode: true
+                with-mpi: 1
+                image-type: deepspeed-gpu
+              - dev-mode: true
+                with-mpi: 1
+                image-type: gpt-neox-deepspeed-gpu
 
       - publish-cloud-images:
           name: publish-cloud-images-dev


### PR DESCRIPTION
## Description

This change addresses 2 separate issues.
1. The 2 deepspeed image types have MPI and no MPI flavors. The MPI flavor is useless. Stop building and publishing it.
2. The previous PR/commit attempted to skip MPI for ROCm. It worked for the dev build but not for the production build (see https://app.circleci.com/pipelines/github/determined-ai/environments ): in production we still built both MPI and no-MPI images. I suspect the reason for that is that the matrix specification for the production build does not explicitly list `dev-mode` as a parameter (the job `build-and-publish-docker` defines this parameter but it defaults to `false`) so the exclusion mechanism gets thrown off by the exclusion definition `{"dev-mode": false, "with-mpi": 1, "image-type": "pytorch10-tf27-rocm50"}` because it does not correspond to a cell in the matrix. I therefore removed `"dev-mode": false` from the exclusion based on the above assumption (fingers crossed). If that does not work I will add an explicit dimension to the matrix `"dev-mode": [false]` and `"dev-mode": false` back into the exclusion.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
