### PR TITLE
fix: pin protobuf just before installing horovod

### DIFF
--- a/Dockerfile-default-cpu
+++ b/Dockerfile-default-cpu
@@ -27,7 +27,6 @@ RUN if [ "$TORCH_PIP" ]; then \
         fi; \
     fi
 RUN if [ "$TORCHVISION_PIP" ]; then pip install $TORCHVISION_PIP; fi
-RUN pip install protobuf==3.20.1
 
 RUN if [ "$TORCH_PROFILER_GIT" ]; then /tmp/det_dockerfile_scripts/torch-tb-profiler-patch.sh; fi
 ARG HOROVOD_PIP=horovod
@@ -37,7 +36,7 @@ ARG HOROVOD_WITHOUT_MXNET=1
 ARG HOROVOD_WITH_MPI
 ARG HOROVOD_CPU_OPERATIONS
 ARG HOROVOD_WITHOUT_MPI
-RUN pip install cmake==3.22.4
+RUN pip install cmake==3.22.4 protobuf==3.20.1
 RUN pip install "$HOROVOD_PIP"
 
 RUN pip install -r /tmp/det_dockerfile_scripts/additional-requirements.txt

--- a/Dockerfile-default-gpu
+++ b/Dockerfile-default-gpu
@@ -13,7 +13,6 @@ ARG TORCH_PROFILER_GIT
 RUN if [ "$TENSORFLOW_PIP" ]; then python -m pip install $TENSORFLOW_PIP; fi
 RUN if [ "$TORCH_PIP" ]; then python -m pip install $TORCH_PIP; fi
 RUN if [ "$TORCHVISION_PIP" ]; then python -m pip install $TORCHVISION_PIP; fi
-RUN pip install protobuf==3.20.1
 
 ARG TF_CUDA_SYM
 RUN if [ "$TF_CUDA_SYM" ]; then ln -s /usr/local/cuda/lib64/libcusolver.so.11 /opt/conda/lib/python3.8/site-packages/tensorflow/python/libcusolver.so.10; fi
@@ -39,7 +38,7 @@ ARG HOROVOD_GPU_OPERATIONS=NCCL
 ARG HOROVOD_WITH_MPI
 ARG HOROVOD_CPU_OPERATIONS
 ARG HOROVOD_WITHOUT_MPI
-RUN pip install cmake==3.22.4
+RUN pip install cmake==3.22.4 protobuf==3.20.1
 RUN if [ -n "${HOROVOD_PIP}" ]; then ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     pip install "$HOROVOD_PIP" && \
     ldconfig; fi


### PR DESCRIPTION
## Description

If TORCH_PROFILER_GIT is specified, the installation _may_ roll protobuf back below 3.20 which results in it, in turn, being upgraded when determined wheel is installed. (I know, this is confusing: if protobuf is anything less than 3.20 when a container starts, the installation of determined will upgrade it to 4.21, and the incompatibility will result in crashing when Tensorflow is loaded).

My solution is to `pip install protobuf==3.20.1` at the very last moment before the conditional installation of horovod.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Testing
Given how the recent changes did not fix all the environments I wrote a little script to test this fix:

```
declare -a Images=(\
	"determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.4" \
	"determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-0.19.4" \
	"determinedai/environments:cuda-11.2-tf-2.5-gpu-0.19.4" \
	"determinedai/environments:py-3.8-tf-2.5-cpu-0.19.4" \
)

for val in ${Images[@]}; do
	echo $val
	det cmd run --config environment.image=$val "pip install /opt/determined/wheels/determined-0.19.4.dev0-py3-none-any.whl && python -c 'import tensorflow'"
done
```
The above fails on the first 2 images and succeeds on the 3rd and 4th image.

The following succeeds for all 4:
```
declare -a Images=(\
	"determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.4" \
	"determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-0.19.4" \
	"determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-0.19.4" \
	"determinedai/environments-dev:py-3.8-tf-2.5-cpu-0.19.4" \
)

for val in ${Images[@]}; do
	echo $val
	det cmd run --config environment.image=$val "pip install /opt/determined/wheels/determined-0.19.4.dev0-py3-none-any.whl && python -c 'import tensorflow'"
done

```

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
