### PR TITLE
Add ssh-rsa hostkey workaround

### DIFF
--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -32,7 +32,8 @@
         "-e cpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `cpu_tf2_environment_name` }}",
         "-e gpu_tf2_environment_name={{ user `docker_registry` }}/{{ user `gpu_tf2_environment_name` }}",
         "-e short_git_hash={{ user `short_git_hash` }}",
-        "-e image_suffix={{ user `image_suffix` }}"
+        "-e image_suffix={{ user `image_suffix` }}",
+        "--ssh-extra-args='-oHostKeyAlgorithms=+ssh-rsa -oPubkeyAcceptedKeyTypes=+ssh-rsa -oIdentitiesOnly=yes'"
       ],
       "user": "ubuntu",
       "only": [


### PR DESCRIPTION
## Description

Inspired by https://github.com/hashicorp/packer-plugin-ansible/issues/69#issuecomment-1342585096, except our version of packer doesn't seem to yet support the `ansible_ssh_extra_args` parameter (at least, it fails when I use it).  The first two args are for rsa hostkeys, and the "identities only" is what the default value is.

We should probably upgrade packer and use the ssh_extra_args instead.  Someday.

https://developer.hashicorp.com/packer/plugins/provisioners/ansible/ansible#ansible_ssh_extra_args

## Checklist

- [x] Bump VERSION to make the pushed images are tagged with the right version.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
