### PR TITLE
fix: torch version in image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,7 @@ define CPU_TF27_TAGS
 endef
 endif
 
+TORCH_VERSION := 1.12
 export CPU_TF27_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-$(TORCH_VERSION)-tf-2.7$(CPU_SUFFIX)
 export GPU_TF27_ENVIRONMENT_NAME := $(CUDA_112_PREFIX)pytorch-$(TORCH_VERSION)-tf-2.7$(GPU_SUFFIX)
 
@@ -284,7 +285,6 @@ TF2_VERSION_SHORT := 2.8
 TF2_VERSION := 2.8.3
 TF2_PIP_CPU := tensorflow-cpu==$(TF2_VERSION)
 TF2_PIP_GPU := tensorflow==$(TF2_VERSION)
-TORCH_VERSION := 1.12
 TORCH_PIP_CPU := torch==1.12.0+cpu torchvision==0.13.0+cpu torchaudio==0.12.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
 TORCH_PIP_GPU := torch==1.12.0+cu113 torchvision==0.13.0+cu113 torchaudio==0.12.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 


### PR DESCRIPTION
## Description

TORCH_VERSION was defined after the definition of image names for images containing tensorflow 2.7. As a result, images had an incorrect name, like `docker pull determinedai/environments:cuda-11.2-pytorch--tf-2.7-gpu-mpi-0.19.10`.

Move the definition above its first use in the Makefile.

Previous build: 
![image](https://user-images.githubusercontent.com/17324129/214979197-f7f68ef9-09ab-4156-adbb-08b364b4a5bf.png)

This branch:
![image](https://user-images.githubusercontent.com/17324129/214979371-7f405e0b-53e6-47e6-ac98-5e8ec1e5f988.png)


## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
