### PR TITLE
build: add targets for CUDA 11.8.0 and 12.0.1

### DIFF
--- a/Dockerfile-base-cpu
+++ b/Dockerfile-base-cpu
@@ -7,6 +7,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 PIP_NO_CACHE_DIR=1
 RUN mkdir -p /var/run/sshd
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		lsb-core \
 		autoconf \
 		automake \
 		autotools-dev \
@@ -14,6 +15,7 @@ RUN apt-get update \
 		ca-certificates \
 		curl \
 		daemontools \
+		libjpeg-dev \
 		libkrb5-dev \
 		libssl-dev \
 		libtool \
@@ -36,6 +38,9 @@ RUN apt-get update \
 	&& rm /etc/ssh/ssh_host_ecdsa_key \
 	&& rm /etc/ssh/ssh_host_ed25519_key \
 	&& rm /etc/ssh/ssh_host_rsa_key
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/root/.cargo/bin:${PATH}
 
 COPY dockerfile_scripts /tmp/det_dockerfile_scripts
 

--- a/Dockerfile-base-gpu
+++ b/Dockerfile-base-gpu
@@ -10,6 +10,7 @@ ARG UBUNTU_VERSION
 RUN mkdir -p /var/run/sshd
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		lsb-core \
 		autoconf \
 		automake \
 		autotools-dev \
@@ -19,6 +20,7 @@ RUN apt-get update \
 		daemontools \
 		ibverbs-providers \
 		libibverbs1 \
+		libjpeg-dev \
 		libkrb5-dev \
 		librdmacm1 \
 		libssl-dev \
@@ -44,12 +46,16 @@ RUN apt-get update \
 	&& rm /etc/ssh/ssh_host_rsa_key \
         && if [ "$UBUNTU_VERSION" = "ubuntu18.04" ]; then ln -s /usr/include/slurm-wlm /usr/include/slurm; fi
 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/root/.cargo/bin:${PATH}
+
 COPY dockerfile_scripts /tmp/det_dockerfile_scripts
 
 ENV PATH="/opt/conda/bin:${PATH}"
 ENV PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1 PYTHONHASHSEED=0
 ARG PYTHON_VERSION
-RUN /tmp/det_dockerfile_scripts/install_python.sh ${PYTHON_VERSION}
+ARG TARGETPLATFORM
+RUN /tmp/det_dockerfile_scripts/install_python.sh ${PYTHON_VERSION} ${TARGETPLATFORM}
 
 ARG WITH_MPI
 ARG UCX_INSTALL_DIR=/container/ucx


### PR DESCRIPTION
## Description

Updates build environments and allow multi-arch publishing of CUDA 11.8.0 and 12.0.1 environments.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
