### PR TITLE
fix: remove pytorch from tf-2.7 image tags [MLG-311]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,9 +250,8 @@ define CPU_TF27_TAGS
 endef
 endif
 
-TORCH_VERSION := 1.12
-export CPU_TF27_ENVIRONMENT_NAME := $(CPU_PREFIX)pytorch-$(TORCH_VERSION)-tf-2.7$(CPU_SUFFIX)
-export GPU_TF27_ENVIRONMENT_NAME := $(CUDA_112_PREFIX)pytorch-$(TORCH_VERSION)-tf-2.7$(GPU_SUFFIX)
+export CPU_TF27_ENVIRONMENT_NAME := $(CPU_PREFIX)tf-2.7$(CPU_SUFFIX)
+export GPU_TF27_ENVIRONMENT_NAME := $(CUDA_112_PREFIX)tf-2.7$(GPU_SUFFIX)
 
 .PHONY: build-tf27-cpu
 build-tf27-cpu: build-cpu-py-38-base
@@ -282,6 +281,7 @@ build-tf27-gpu: build-gpu-cuda-112-base
 		-t $(NGC_REGISTRY)/$(GPU_TF27_ENVIRONMENT_NAME)-$(VERSION) \
 		.
 
+TORCH_VERSION := 1.12
 TF2_VERSION_SHORT := 2.8
 TF2_VERSION := 2.8.3
 TF2_PIP_CPU := tensorflow-cpu==$(TF2_VERSION)


### PR DESCRIPTION
## Description

The substring `pytorch-1.12` was in the tags for images built without PyTorch. This mistake was introduced in cd272fd.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
