### PR TITLE
chore: bump ubuntu ami versions

### DIFF
--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -2,10 +2,10 @@
   "variables": {
     "aws_access_key_id": "{{ env `AWS_ACCESS_KEY_ID` }}",
     "aws_secret_access_key": "{{ env `AWS_SECRET_ACCESS_KEY` }}",
-    "aws_base_image": "ami-077ee47512dc6f3ca",
+    "aws_base_image": "ami-0ceeab680f529cc36",
     "gov_aws_access_key_id": "{{ env `GOV_AWS_ACCESS_KEY_ID` }}",
     "gov_aws_secret_access_key": "{{ env `GOV_AWS_SECRET_ACCESS_KEY` }}",
-    "gov_aws_base_image": "ami-029a634618d6c0300",
+    "gov_aws_base_image": "ami-0cbd5dbd94f397bdd",
     "gcp_base_image": "ubuntu-2004-focal-v20220118",
     "image_description": "Determined environments",
     "cpu_tf2_environment_name": "{{ env `CPU_TF2_ENVIRONMENT_NAME` }}",


### PR DESCRIPTION
## Description

Run refresh-ubuntu-amis.py on environments-packer.json

This follows an update that fixed refresh-ubuntu-amis.py. See MLG-421.


## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

