### PR TITLE
chore: CircleCi GPU instances, DeepSpeed 0.8.3 [MLG-399]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ workflows:
   publish:
     jobs:
       - build-and-publish-docker:
-          name: build-and-publish-docker-cpu
+          name: build-and-publish-docker
           context: determined-production
           filters:
             branches:
@@ -174,7 +174,7 @@ workflows:
               - with-mpi: 1
                 image-type: pytorch10-tf27-rocm50
       - build-and-publish-docker:
-          name: build-and-publish-docker-gpu
+          name: build-and-publish-docker
           context: determined-production
           filters:
             branches:
@@ -209,7 +209,7 @@ workflows:
           filters: *upstream-feature-branch
 
       - build-and-publish-docker:
-          name: build-and-publish-docker-cpu-<<matrix.image-type>>-<<matrix.with-mpi>>-dev
+          name: build-and-publish-docker-<<matrix.image-type>>-<<matrix.with-mpi>>-dev
           context: determined-production
           filters: *upstream-feature-branch
           requires:
@@ -235,7 +235,7 @@ workflows:
                 image-type: pytorch10-tf27-rocm50
 
       - build-and-publish-docker:
-          name: build-and-publish-docker-gpu-<<matrix.image-type>>-dev
+          name: build-and-publish-docker-<<matrix.image-type>>-dev
           context: determined-production
           filters: *upstream-feature-branch
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,7 @@ workflows:
             branches:
               only: main
           matrix:
+            alias: build-docker-all-cpu
             parameters:
               with-mpi: [0, 1]
               image-type:
@@ -179,9 +180,12 @@ workflows:
             branches:
               only: master
           matrix:
+            alias: build-docker-all-gpu
             parameters:
-              ci-image: ubuntu-2004-cuda-11.4:202110-01
-              ci-resource_class: gpu.nvidia.small
+              ci-image:
+                - ubuntu-2004-cuda-11.4:202110-01
+              ci-resource_class:
+                - gpu.nvidia.small
               image-type:
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu
@@ -191,8 +195,8 @@ workflows:
             branches:
               only: main
           requires:
-            - build-and-publish-docker-cpu
-            - build-and-publish-docker-gpu
+            - build-docker-all-cpu
+            - build-docker-all-gpu
 
   publish-dev:
     jobs:
@@ -240,8 +244,10 @@ workflows:
             alias: build-docker-all-gpu
             parameters:
               dev-mode: [true]
-              ci-image: ubuntu-2004-cuda-11.4:202110-01
-              ci-resource_class: gpu.nvidia.small
+              ci-image:
+                - ubuntu-2004-cuda-11.4:202110-01
+              ci-resource_class:
+                - gpu.nvidia.small
               image-type:
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,12 @@ commands:
 jobs:
   build-and-publish-docker:
     parameters:
+      ci-image:
+        type: string
+        default: ubuntu-2004:2022.04.2
+      ci-resource_class:
+        type: string
+        default: xlarge
       image-type:
         type: string
       dev-mode:
@@ -75,8 +81,8 @@ jobs:
         type: integer
         default: 0
     machine:
-      image: ubuntu-2004:2022.04.2
-    resource_class: xlarge
+      image: <<parameters.ci-image>>
+    resource_class: <<parameters.ci-resource_class>>
     steps:
       - checkout
       - install-docker
@@ -162,16 +168,21 @@ workflows:
                 - tf28-gpu
                 - pt-gpu
                 - pytorch10-tf27-rocm50
-                - deepspeed-gpu
-                - gpt-neox-deepspeed-gpu
             exclude:
               - with-mpi: 1
                 image-type: pytorch10-tf27-rocm50
-              - with-mpi: 1
-                image-type: deepspeed-gpu
-              - with-mpi: 1
-                image-type: gpt-neox-deepspeed-gpu
-
+      - build-and-publish-docker:
+          context: determined-production
+          filters:
+            branches:
+              only: master
+          matrix:
+            parameters:
+              ci-image: ubuntu-2004-cuda-11.4:202110-01
+              ci-resource_class: gpu.nvidia.small
+              image-type:
+                - deepspeed-gpu
+                - gpt-neox-deepspeed-gpu
       - publish-cloud-images:
           context: determined-production
           filters:
@@ -211,18 +222,26 @@ workflows:
                 - tf28-gpu
                 - pt-gpu
                 - pytorch10-tf27-rocm50
-                - deepspeed-gpu
-                - gpt-neox-deepspeed-gpu
             exclude:
               - dev-mode: true
                 with-mpi: 1
                 image-type: pytorch10-tf27-rocm50
-              - dev-mode: true
-                with-mpi: 1
-                image-type: deepspeed-gpu
-              - dev-mode: true
-                with-mpi: 1
-                image-type: gpt-neox-deepspeed-gpu
+
+      - build-and-publish-docker:
+          name: build-and-publish-docker-<<matrix.image-type>>-dev
+          context: determined-production
+          filters: *upstream-feature-branch
+          requires:
+            - request-publish-dev-docker
+          matrix:
+            alias: build-docker-all
+            parameters:
+              dev-mode: [true]
+              ci-image: ubuntu-2004-cuda-11.4:202110-01
+              ci-resource_class: gpu.nvidia.small
+              image-type:
+                - deepspeed-gpu
+                - gpt-neox-deepspeed-gpu
 
       - publish-cloud-images:
           name: publish-cloud-images-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ workflows:
   publish:
     jobs:
       - build-and-publish-docker:
+          name: build-and-publish-docker-cpu
           context: determined-production
           filters:
             branches:
@@ -172,6 +173,7 @@ workflows:
               - with-mpi: 1
                 image-type: pytorch10-tf27-rocm50
       - build-and-publish-docker:
+          name: build-and-publish-docker-gpu
           context: determined-production
           filters:
             branches:
@@ -189,7 +191,8 @@ workflows:
             branches:
               only: main
           requires:
-            - build-and-publish-docker
+            - build-and-publish-docker-cpu
+            - build-and-publish-docker-gpu
 
   publish-dev:
     jobs:
@@ -202,13 +205,13 @@ workflows:
           filters: *upstream-feature-branch
 
       - build-and-publish-docker:
-          name: build-and-publish-docker-<<matrix.image-type>>-<<matrix.with-mpi>>-dev
+          name: build-and-publish-docker-cpu-<<matrix.image-type>>-<<matrix.with-mpi>>-dev
           context: determined-production
           filters: *upstream-feature-branch
           requires:
             - request-publish-dev-docker
           matrix:
-            alias: build-docker-all
+            alias: build-docker-all-cpu
             parameters:
               dev-mode: [true]
               with-mpi: [0, 1]
@@ -228,13 +231,13 @@ workflows:
                 image-type: pytorch10-tf27-rocm50
 
       - build-and-publish-docker:
-          name: build-and-publish-docker-<<matrix.image-type>>-dev
+          name: build-and-publish-docker-gpu-<<matrix.image-type>>-dev
           context: determined-production
           filters: *upstream-feature-branch
           requires:
             - request-publish-dev-docker
           matrix:
-            alias: build-docker-all
+            alias: build-docker-all-gpu
             parameters:
               dev-mode: [true]
               ci-image: ubuntu-2004-cuda-11.4:202110-01
@@ -248,6 +251,7 @@ workflows:
           context: determined-production
           filters: *upstream-feature-branch
           requires:
-            - build-docker-all
+            - build-docker-all-cpu
+            - build-docker-all-gpu
             - request-publish-dev-cloud
           dev-mode: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ workflows:
           context: determined-production
           filters:
             branches:
-              only: master
+              only: main
           matrix:
             alias: build-docker-all-gpu
             parameters:
@@ -186,6 +186,7 @@ workflows:
                 - ubuntu-2004-cuda-11.4:202110-01
               ci-resource_class:
                 - gpu.nvidia.small
+              with-mpi: [0]
               image-type:
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu
@@ -235,7 +236,7 @@ workflows:
                 image-type: pytorch10-tf27-rocm50
 
       - build-and-publish-docker:
-          name: build-and-publish-docker-<<matrix.image-type>>-dev
+          name: build-and-publish-docker-<<matrix.image-type>>-<<matrix.with-mpi>>-dev
           context: determined-production
           filters: *upstream-feature-branch
           requires:
@@ -248,6 +249,7 @@ workflows:
                 - ubuntu-2004-cuda-11.4:202110-01
               ci-resource_class:
                 - gpu.nvidia.small
+              with-mpi: [0]
               image-type:
                 - deepspeed-gpu
                 - gpt-neox-deepspeed-gpu


### PR DESCRIPTION
## Description

This PR upgrades our Docker images to use DeepSpeed 0.8.3 (up from 0.7.0). A major side-effect of this upgrade is that these images must be built on machine with a GPU present. This required waiting for our contract with CircleCI to renew as yearly, granting us access to their GPU instances. Using these required changes to our CircleCI configuration: we have split the build jobs into two sets, one with the same CPU setup as before and the other - for DeepSpeed and DeepSpeed/NeoX - with a GPU setup. 

These images have already been tested in the draft PR [#6614](https://github.com/determined-ai/determined/pull/6614). Specifically, the job `test-e2e-deepspeed` [succeeded](https://app.circleci.com/pipelines/github/determined-ai/determined/37272/workflows/0e0355d9-5528-44ec-aef8-441b21d2c648/jobs/1352039).

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
