### PR TITLE
fix: use `CMD /bin/bash` by default.

### DIFF
--- a/Dockerfile-base-gpu
+++ b/Dockerfile-base-gpu
@@ -114,6 +114,6 @@ RUN /tmp/det_dockerfile_scripts/install_libnss_determined.sh
 RUN mkdir -p /container/bin && \
     cp /tmp/det_dockerfile_scripts/scrape_libs.sh /container/bin
 ENTRYPOINT ["/container/bin/scrape_libs.sh"]
+CMD ["/bin/bash"]
 
 RUN rm -r /tmp/*
-


### PR DESCRIPTION
## Description

Since we now set a custom entrypoint script, let's also set command to `/bin/bash` as well to make `docker run -it IMAGE_TAG` work.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
