### PR TITLE
fix: move "determined" to front in nsswitch.conf

### DIFF
--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -84,7 +84,7 @@
         "us-east-2"
       ],
       "source_ami": "{{ user `aws_base_image`}}",
-      "instance_type": "p2.xlarge",
+      "instance_type": "g4dn.xlarge",
       "ssh_username": "ubuntu",
       "launch_block_device_mappings": [
         {

--- a/dockerfile_scripts/install_libnss_determined.sh
+++ b/dockerfile_scripts/install_libnss_determined.sh
@@ -5,5 +5,19 @@ set -e
 # Add a plugin to the user system that lets us extend the users available in
 # the container at runtime. This is critical for supporting non-root shell,
 # which in turn is critical for non-root distributed training.
+#
+# Also, to work around a behavior in OpenShift 4.+ [1], place `determined`
+# NSS plug-in to be searched first instead of last so Determined-defined
+# entries are used when there are conflicts with infrastructure-based
+# entries in these identity databases: passwd, shadow, group.
+#
+# [1] https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids "By default,
+# OpenShift 4.x appends the effective UID into /etc/passwd of the Container
+# during the creation of the Pod."
+
 make -C /tmp/det_dockerfile_scripts/libnss_determined libnss_determined.so.2 install \
-    && sed -E -i -e 's/^((passwd|shadow|group):.*)/\1 determined/' /etc/nsswitch.conf
+    && sed -i -E '
+        /^(passwd|group|shadow):/{
+            s/[ \t]determined//;
+            s/:/: determined/;
+        }' /etc/nsswitch.conf


### PR DESCRIPTION
## Description

[HELP-51](https://hpe-aiatscale.atlassian.net/browse/HELP-51)

In `nsswitch.conf` move "determined" to the front of the list so Determined-created identity entries are picked up first.  This prevents conflicting entries that may be added by the infrastructure.

In the ticket linked above, distributed training via SSH, e.g. Horovod, on OpenShift 4.+ gets thrown off by [CRI-O injecting a `passwd` entry](https://github.com/cri-o/cri-o/pull/2022/commits/77408ef1490002e62c88baacc5c994e97aa793c6) that interferes with the SSH client identity as expected by Determined.

@dougdet worked with @rb-determined-ai on this solution.

## Checklist

- [x] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[HELP-51]: https://hpe-aiatscale.atlassian.net/browse/HELP-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ