### PR TITLE
Fix: MPI test failure with images built with WITH_MPI=1

### DIFF
--- a/Dockerfile-default-gpu
+++ b/Dockerfile-default-gpu
@@ -8,7 +8,8 @@ RUN /tmp/det_dockerfile_scripts/install_google_cloud_sdk.sh
 ARG WITH_NCCL
 # Make it look for the system nccl, which hopefully is the newer one we built
 # and installed
-ENV HOROVOD_NCCL_HOME="/container/nccl"
+
+ENV HOROVOD_NCCL_HOME=${WITH_NCCL:+"/container/nccl"}
 ENV HOROVOD_NCCL_LINK=${WITH_NCCL:+SHARED}
 
 RUN if [ -n "${WITH_NCCL}" ]; then /tmp/det_dockerfile_scripts/build_nccl.sh; fi

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ UBUNTU_IMAGE_TAG := ubuntu:20.04
 UBUNTU_VERSION_1804 := ubuntu18.04
 PLATFORM_LINUX_ARM_64 := linux/arm64
 PLATFORM_LINUX_AMD_64 := linux/amd64
+HOROVOD_GPU_OPERATIONS := NCCL
 
 ifeq "$(WITH_MPI)" "1"
 # 	Don't bother supporting or building arm64+mpi builds.
@@ -38,12 +39,9 @@ ifeq "$(WITH_MPI)" "1"
 	NCCL_BUILD_ARG := WITH_NCCL
         ifeq "$(WITH_NCCL)" "1"
 		NCCL_BUILD_ARG := WITH_NCCL=1
-		HOROVOD_GPU_OPERATIONS := NCCL
 		ifeq "$(WITH_AWS_TRACE)" "1"
 			WITH_AWS_TRACE := 1
 		endif
-        else
-		HOROVOD_GPU_OPERATIONS := MPI
         endif
 	MPI_BUILD_ARG := WITH_MPI=1
 
@@ -63,7 +61,6 @@ else
 	HOROVOD_WITH_MPI := 0
 	HOROVOD_WITHOUT_MPI := 1
 	HOROVOD_CPU_OPERATIONS := GLOO
-	HOROVOD_GPU_OPERATIONS := NCCL
 	MPI_BUILD_ARG := USE_GLOO=1
 endif
 


### PR DESCRIPTION
* Subject: Fix MPI test failure with images built with WITH_MPI=1

Description:
This mod addresses MPI test failures introduced with commit de2a152.

Updated environment variable NCCL_HOME with the "WITH_NCCL" setting. Updated HOROVOD_GPU_OPERATION to "NCCL" in MPI builds. Builds with "WITH_MPI=0" are unchanged.

Builds are successfully executed on the AWS ubuntu servers.
Tests are executed and passed on Grenoble champollion and slingshot nodes. Tests are executed and passed on Osprey GPU and CPU nodes.

MPI builds:
make DOCKER_BUILD_OPTS="--no-cache" WITH_MPI=1 WITH_NCCL=0 WITH_OFI=0 build-tf1-gpu make DOCKER_BUILD_OPTS="--no-cache" WITH_MPI=1 WITH_NCCL=0 WITH_OFI=0 build-tf2-gpu make DOCKER_BUILD_OPTS="--no-cache" WITH_MPI=1 WITH_NCCL=0 WITH_OFI=0 build-tf1-cpu make DOCKER_BUILD_OPTS="--no-cache" WITH_MPI=1 WITH_NCCL=0 WITH_OFI=0 build-tf2-cpu

MPI with OFI build:
make DOCKER_BUILD_OPTS="--no-cache" WITH_MPI=1 WITH_NCCL=1 WITH_OFI=1 build-tf2-gpu

MPI tests on Grenoble:
env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=1 -p champollion singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-9d14054.sif /cstor/builder/o184i023/cactus-test-framework/apps/osu-micro-benchmarks-5.7/mpi/one-sided/osu_get_bw

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p champollion -t 240 singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-9d14054.sif python3 test/scripts/tensorflow2_mnist.py

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p champollion -t 240 singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-9d14054.sif python3 benchmarks/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --num_batches 25 --variable_update horovod

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p champollion -t 240 singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-9d14054.sif python3 horovod/examples/tensorflow2/tensorflow2_synthetic_benchmark.py --num-iters 4

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p champollion singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-9d14054.sif python3 test/scripts/pytorch_mnist.py

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p champollion -t 120 singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-9d14054.sif python3 horovod/examples/pytorch/pytorch_synthetic_benchmark.py

MPI with OFI tests on Grenoble:
env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=1 -p slingshot singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-ofi-9d14054.sif /cstor/builder/o184i023/cactus-test-framework/apps/osu-micro-benchmarks-5.7/mpi/one-sided/osu_get_bw

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p slingshot -t 240 singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-ofi-9d14054.sif python3 benchmarks/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model resnet101 --batch_size 64 --num_batches 25 --variable_update horovod

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p slingshot -t 240 singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-ofi-9d14054.sif python3 horovod/examples/tensorflow2/tensorflow2_synthetic_benchmark.py --num-iters 4

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p slingshot singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-ofi-9d14054.sif python3 test/scripts/pytorch_mnist.py

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --mpi=pmi2 -n 2 --ntasks-per-node=4 -p slingshot singularity exec --nv --bind /cstor /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-ofi-9d14054.sif python3 horovod/examples/pytorch/pytorch_synthetic_benchmark.py

env NCCL_DEBUG=TRACE env CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 srun --cpu-freq=high --gpu-freq=high --mpi=pmi2 -n 8 --ntasks-per-node=4 -p slingshot -t 45 singularity exec --nv --bind /cstor,/cstor/builder/lib:/host/lib /cstor/builder/detai-env-images/detai-cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-ofi-9d14054.sif ./hpc-ard-CosmoGan-benchmark/GPU/run_python.sh python3 hpc-ard-CosmoGan-benchmark/GPU/run_dcgan.py
