### PR TITLE
fix: revert libnss_determined-goes-first

### DIFF
--- a/dockerfile_scripts/install_libnss_determined.sh
+++ b/dockerfile_scripts/install_libnss_determined.sh
@@ -6,18 +6,24 @@ set -e
 # the container at runtime. This is critical for supporting non-root shell,
 # which in turn is critical for non-root distributed training.
 #
-# Also, to work around a behavior in OpenShift 4.+ [1], place `determined`
-# NSS plug-in to be searched first instead of last so Determined-defined
-# entries are used when there are conflicts with infrastructure-based
-# entries in these identity databases: passwd, shadow, group.
+# By default, the NSS plugin is placed last, which means it won't override any
+# settings present in the container's /etc/passwd.  However, if `--first` is
+# passed to the script, the NSS plugin is placed first.  This is necessary when
+# another system would conflict with Determined's system requirements.  An
+# example is OpenShift 4.+ [1].
 #
 # [1] https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids "By default,
 # OpenShift 4.x appends the effective UID into /etc/passwd of the Container
 # during the creation of the Pod."
 
-make -C /tmp/det_dockerfile_scripts/libnss_determined libnss_determined.so.2 install \
-    && sed -i -E '
+make -C /tmp/det_dockerfile_scripts/libnss_determined libnss_determined.so.2 install
+
+if [ "$1" = "--first" ]; then
+    sed -i -E -e '
         /^(passwd|group|shadow):/{
             s/[ \t]determined//;
             s/:/: determined/;
         }' /etc/nsswitch.conf
+else
+    sed -E -i -e 's/^((passwd|shadow|group):.*)/\1 determined/' /etc/nsswitch.conf
+fi


### PR DESCRIPTION
It appears that placing our libnss plugin first is good for openshift, but bad for slurm.

If we have to pick, we should optimize for the slurm users.

Additionally, placing our plugin last offers the least surprise, I think, as it doesn't override whatever else the user had configured in their image (which was the original motivation for having it last).

Our install_libnss_determined.sh now accepts a --first option to get the openshift-friendly behavior.  This is likely more useful as documentation strategy than for any real users.