### PR TITLE
fix: nvidia only has ubuntu 18.04 images now [MLG-1194]

### DIFF
--- a/cloud/roles/nvidia-container-toolkit/tasks/main.yml
+++ b/cloud/roles/nvidia-container-toolkit/tasks/main.yml
@@ -14,7 +14,7 @@
     state: present
     update_cache: yes
   with_items:
-    - deb https://nvidia.github.io/libnvidia-container/ubuntu18.04/amd64 /
+    - deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/amd64 /
     - deb https://nvidia.github.io/nvidia-container-runtime/ubuntu18.04/amd64 /
     - deb https://nvidia.github.io/nvidia-docker/ubuntu18.04/amd64 /
 

--- a/cloud/roles/nvidia-container-toolkit/tasks/main.yml
+++ b/cloud/roles/nvidia-container-toolkit/tasks/main.yml
@@ -14,9 +14,9 @@
     state: present
     update_cache: yes
   with_items:
-    - deb https://nvidia.github.io/libnvidia-container/ubuntu20.04/amd64 /
-    - deb https://nvidia.github.io/nvidia-container-runtime/ubuntu20.04/amd64 /
-    - deb https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64 /
+    - deb https://nvidia.github.io/libnvidia-container/ubuntu18.04/amd64 /
+    - deb https://nvidia.github.io/nvidia-container-runtime/ubuntu18.04/amd64 /
+    - deb https://nvidia.github.io/nvidia-docker/ubuntu18.04/amd64 /
 
 - name: Install Nvidia Container Toolkit..
   become: yes


### PR DESCRIPTION
## Description

apparently nvidia decided to axe ubuntu22.04 images for nvidia-container-toolkit, and only support an older EOL 18.04...

see https://github.com/NVIDIA/nvidia-container-toolkit/issues/96 for appropriate context.


## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] Test the images by running the test `bumpenvs` procedure in the determined repo. See [README](https://github.com/determined-ai/environments/blob/main/README.md).


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
