### PR TITLE
PAD-101: Updated build-gpu-ngc-gh-deepspeed to work with llama2 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,15 +194,18 @@ workflows:
                 - pt-gpu
                 - pt2-gpu
                 - tensorflow-ngc
-                - pytorch13-tf210-rocm56
-                - pytorch20-tf210-rocm56
+                - pytorch13-tf210-rocm57
+                - pytorch20-tf210-rocm57
+                - pytorch13-tf210-rocm60
+                - pytorch20-tf210-rocm60
             exclude:
               - with-mpi: 1
-                image-type: pytorch13-tf210-rocm56
-              - with-mpi: 1
-                image-type: pytorch20-tf210-rocm56
-              - with-mpi: 1
-                image-type: tensorflow-ngc
+                image-type: 
+                  - pytorch13-tf210-rocm57
+                  - pytorch20-tf210-rocm57
+                  - pytorch13-tf210-rocm60
+                  - pytorch20-tf210-rocm60
+                  - tensorflow-ngc
       - build-and-publish-docker:
           name: build-and-publish-docker-<<matrix.image-type>>-<<matrix.with-mpi>>
           context: determined-production
@@ -261,18 +264,19 @@ workflows:
                 - pt-gpu
                 - pt2-gpu
                 - tensorflow-ngc
-                - pytorch13-tf210-rocm56
-                - pytorch20-tf210-rocm56
+                - pytorch13-tf210-rocm57
+                - pytorch20-tf210-rocm57
+                - pytorch13-tf210-rocm60
+                - pytorch20-tf210-rocm60
             exclude:
               - dev-mode: true
                 with-mpi: 1
-                image-type: pytorch13-tf210-rocm56
-              - dev-mode: true
-                with-mpi: 1
-                image-type: pytorch20-tf210-rocm56
-              - dev-mode: true
-                with-mpi: 1
-                image-type: tensorflow-ngc
+                image-type: 
+                  - pytorch13-tf210-rocm57
+                  - pytorch20-tf210-rocm57
+                  - pytorch13-tf210-rocm60
+                  - pytorch20-tf210-rocm60
+                  - tensorflow-ngc
 
       - build-and-publish-docker:
           name: build-and-publish-docker-<<matrix.image-type>>-<<matrix.with-mpi>>-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,15 +196,11 @@ workflows:
                 - tensorflow-ngc
                 - pytorch13-tf210-rocm57
                 - pytorch20-tf210-rocm57
-                - pytorch13-tf210-rocm60
-                - pytorch20-tf210-rocm60
             exclude:
               - with-mpi: 1
                 image-type: 
                   - pytorch13-tf210-rocm57
                   - pytorch20-tf210-rocm57
-                  - pytorch13-tf210-rocm60
-                  - pytorch20-tf210-rocm60
                   - tensorflow-ngc
       - build-and-publish-docker:
           name: build-and-publish-docker-<<matrix.image-type>>-<<matrix.with-mpi>>
@@ -223,7 +219,6 @@ workflows:
                 - gpu.nvidia.small.multi
               with-mpi: [0]
               image-type:
-                - deepspeed
                 - gpt-neox-deepspeed
                 - pytorch-ngc
       - publish-cloud-images:
@@ -266,16 +261,12 @@ workflows:
                 - tensorflow-ngc
                 - pytorch13-tf210-rocm57
                 - pytorch20-tf210-rocm57
-                - pytorch13-tf210-rocm60
-                - pytorch20-tf210-rocm60
             exclude:
               - dev-mode: true
                 with-mpi: 1
                 image-type: 
                   - pytorch13-tf210-rocm57
                   - pytorch20-tf210-rocm57
-                  - pytorch13-tf210-rocm60
-                  - pytorch20-tf210-rocm60
                   - tensorflow-ngc
 
       - build-and-publish-docker:
@@ -296,7 +287,6 @@ workflows:
                 - gpu.nvidia.small.multi
               with-mpi: [0]
               image-type:
-                - deepspeed
                 - gpt-neox-deepspeed
                 - pytorch-ngc
 

--- a/Dockerfile-ngc
+++ b/Dockerfile-ngc
@@ -39,6 +39,15 @@ RUN apt-get update \
 		
 COPY dockerfile_scripts /tmp/det_dockerfile_scripts
 
+ARG WITH_NCCL
+# Make it look for the system nccl, which hopefully is the newer one we built
+# and installed
+
+ENV HOROVOD_NCCL_HOME=${WITH_NCCL:+"/container/nccl"}
+ENV HOROVOD_NCCL_LINK=${WITH_NCCL:+SHARED}
+
+RUN if [ -n "${WITH_NCCL}" ]; then /tmp/det_dockerfile_scripts/build_nccl.sh; fi
+
 ARG WITH_MPI
 ARG WITH_OFI
 ARG UCX_INSTALL_DIR=/container/ucx

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,8 @@ NGC_PYTORCH_VERSION := 23.12-py3
 NGC_TENSORFLOW_VERSION := 23.12-tf2-py3
 NGC_DEEPSPEED_VERSION := 0.13.0
 
-NGC_GH_PYTORCH_VERSION=23.09-py3
+NGC_GH_PYTORCH_VERSION=23.10-py3
+NGC_GH_PYTORCH_38_VERSION=22.12-py3
 NGCPLUS_GH_BASE=pytorch-gh-ngc-base
 NGCPLUS_GH_DS=pytorch-gh-ds-ngc
 
@@ -197,7 +198,7 @@ HOROVOD_PIP_COMMAND := horovod==0.28.1
 .PHONY: build-gpu-ngc-gh-base
 build-gpu-ngc-gh-base:
 	docker build -f Dockerfile-ngc \
-	        --build-arg BASE_IMAGE="nvcr.io/nvidia/pytorch:23.09-py3" \
+		--build-arg BASE_IMAGE=$(NGC_PYTORCH_PREFIX):$(NGC_GH_PYTORCH_VERSION) \
                 --build-arg TENSORFLOW_PIP="$(TF2_PIP_GPU)" \
                 --build-arg HOROVOD_PIP="$(HOROVOD_PIP_COMMAND)" \
                 --build-arg WITH_AWS_TRACE="$(WITH_AWS_TRACE)" \
@@ -231,7 +232,7 @@ NGC_GH_TF_VERSION=tf2-py3
 build-gpu-ngc-tf-gh-base:
 	docker build -f Dockerfile-ngc-tf \
                 --no-cache \
-                --build-arg BASE_IMAGE="nvcr.io/nvidia/tensorflow:23.10-tf2-py3" \
+                --build-arg BASE_IMAGE=$(NGC_TENSORFLOW_PREFIX):$(NGC_TENSORFLOW_VERSION) \
                 --build-arg HOROVOD_PIP="$(HOROVOD_PIP_COMMAND)" \
                 --build-arg WITH_AWS_TRACE="$(WITH_AWS_TRACE)" \
                 --build-arg INTERNAL_AWS_DS="$(INTERNAL_AWS_DS)" \
@@ -251,7 +252,7 @@ build-gpu-ngc-tf-gh-base:
 .PHONY: build-gpu-ngc-py38-gh-base
 build-gpu-ngc-py38-gh-base:
 	docker build -f Dockerfile-ngc-py38 \
-                --build-arg BASE_IMAGE="nvcr.io/nvidia/pytorch:23.03-py3" \
+                --build-arg BASE_IMAGE=$(NGC_PYTORCH_PREFIX):$(NGC_GH_PYTORCH_38_VERSION) \
                 --build-arg TENSORFLOW_PIP="$(TF2_PIP_GPU)" \
                 --build-arg HOROVOD_PIP="$(HOROVOD_PIP_COMMAND)" \
                 --build-arg WITH_AWS_TRACE="$(WITH_AWS_TRACE)" \
@@ -265,28 +266,28 @@ build-gpu-ngc-py38-gh-base:
                 --build-arg HOROVOD_CPU_OPERATIONS="$(HOROVOD_CPU_OPERATIONS)" \
                 --build-arg HOROVOD_GPU_OPERATIONS="$(HOROVOD_GPU_OPERATIONS)" \
                 --build-arg HOROVOD_GPU_ALLREDUCE="$(HOROVOD_GPU_ALLREDUCE)" \
-                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_BASE)-py38-$(NGC_GH_PYTORCH_VERSION)-$(SHORT_GIT_HASH) \
-                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_BASE)-py38-$(NGC_GH_PYTORCH_VERSION)-$(VERSION) \
+                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_BASE)-py38-$(NGC_GH_PYTORCH_38_VERSION)-$(SHORT_GIT_HASH) \
+                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_BASE)-py38-$(NGC_GH_PYTORCH_38_VERSION)-$(VERSION) \
                 .
 
 .PHONY: build-gpu-ngc-py38-gh-deepspeed
 build-gpu-ngc-py38-gh-deepspeed: build-gpu-ngc-py38-gh-base
 	docker build -f Dockerfile-ngc-ds \
-                --build-arg BASE_IMAGE="$(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_BASE)-py38-$(NGC_GH_PYTORCH_VERSION)-$(VERSION)" \
+                --build-arg BASE_IMAGE="$(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_BASE)-py38-$(NGC_GH_PYTORCH_38_VERSION)-$(VERSION)" \
                 --build-arg TORCH_CUDA_ARCH_LIST="6.0;6.1;6.2;7.0;7.5;8.0;9.0" \
                 --build-arg DEEPSPEED_PIP="git+https://github.com/EleutherAI/DeeperSpeed@v2.0"   \
-                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_DS)-py38-$(NGC_GH_PYTORCH_VERSION)-$(SHORT_GIT_HASH) \
-                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_DS)-py38-$(NGC_GH_PYTORCH_VERSION)-$(VERSION) \
+                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_DS)-py38-$(NGC_GH_PYTORCH_38_VERSION)-$(SHORT_GIT_HASH) \
+                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_DS)-py38-$(NGC_GH_PYTORCH_38_VERSION)-$(VERSION) \
                 .
 
 .PHONY: build-gpu-ngc-py38-gh-neox
 build-gpu-ngc-py38-gh-neox: build-gpu-ngc-py38-gh-base
 	docker build -f Dockerfile-ngc-neox \
-                --build-arg BASE_IMAGE="$(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_BASE)-py38-$(NGC_GH_PYTORCH_VERSION)-$(VERSION)" \
+                --build-arg BASE_IMAGE="$(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_BASE)-py38-$(NGC_GH_PYTORCH_38_VERSION)-$(VERSION)" \
                 --build-arg TORCH_CUDA_ARCH_LIST="6.0;6.1;6.2;7.0;7.5;8.0;9.0" \
                 --build-arg DEEPSPEED_PIP="git+https://github.com/EleutherAI/DeeperSpeed@v2.0"   \
-                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_DS)-py38-neox-$(NGC_GH_PYTORCH_VERSION)-$(SHORT_GIT_HASH) \
-                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_DS)-py38-neox-$(NGC_GH_PYTORCH_VERSION)-$(VERSION) \
+                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_DS)-py38-neox-$(NGC_GH_PYTORCH_38_VERSION)-$(SHORT_GIT_HASH) \
+                -t $(DOCKERHUB_REGISTRY)/$(NGCPLUS_GH_DS)-py38-neox-$(NGC_GH_PYTORCH_38_VERSION)-$(VERSION) \
                 .
 
 # build hpc together since hpc is dependent on the normal build

--- a/dockerfile_scripts/build_aws.sh
+++ b/dockerfile_scripts/build_aws.sh
@@ -17,8 +17,8 @@ if [ "$OFI" = "1" ]; then
                 tcsh
 
   # Install AWS_OFI_NCCL
-  AWS_VER=v1.6.0
-  AWS_VER_NUM=1.6.0
+  AWS_VER=v1.4.0
+  AWS_VER_NUM=1.4.0
   AWS_NAME=aws-ofi-nccl
   AWS_FILE="${AWS_NAME}-${AWS_VER_NUM}"
   # cuda install dir likely dependent on BaseOS (i.e. ubuntu 20.02)


### PR DESCRIPTION
## Description
Update build-gpu-ngc-gh-deepspped for llama2 test.
Added WITH_NCCL support and revert AWS version to 1.4.0.