### PR TITLE
feat: set NGC+ images as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,9 @@ define CPU_PYTORCH_TAGS
 endef
 endif
 
+export DEFAULT_CPU_IMAGE=$(DOCKERHUB_REGISTRY)/$(CPU_PYTORCH_ENVIRONMENT_NAME):$(SHORT_GIT_HASH)
+export DEFAULT_CUDA_IMAGE=$(DOCKERHUB_REGISTRY)/$(CPU_PYTORCH_ENVIRONMENT_NAME):$(SHORT_GIT_HASH)
+
 .PHONY: build-pytorch-cpu
 build-pytorch-cpu: build-cpu-py-310-base
 	docker buildx build -f Dockerfile-default-cpu \

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ NGC_PYTORCH_PREFIX := nvcr.io/nvidia/pytorch
 NGC_TENSORFLOW_PREFIX := nvcr.io/nvidia/tensorflow
 NGC_PYTORCH_VERSION := 24.03-py3
 NGC_TENSORFLOW_VERSION := 24.03-tf2-py3
-NGC_PYTORCH_REPO := pytorch-ngc-dev
+export NGC_PYTORCH_REPO := pytorch-ngc-dev
 NGC_PYTORCH_HPC_REPO := pytorch-ngc-hpc-dev
 NGC_TF_REPO := tensorflow-ngc-dev
 NGC_TF_HPC_REPO := tensorflow-ngc-hpc-dev
@@ -295,9 +295,6 @@ define CPU_PYTORCH_TAGS
 -t $(NGC_REGISTRY)/$(CPU_PYTORCH_ENVIRONMENT_NAME):$(SHORT_GIT_HASH)
 endef
 endif
-
-export DEFAULT_CPU_IMAGE=$(DOCKERHUB_REGISTRY)/$(CPU_PYTORCH_ENVIRONMENT_NAME):$(SHORT_GIT_HASH)
-export DEFAULT_CUDA_IMAGE=$(DOCKERHUB_REGISTRY)/$(CPU_PYTORCH_ENVIRONMENT_NAME):$(SHORT_GIT_HASH)
 
 .PHONY: build-pytorch-cpu
 build-pytorch-cpu: build-cpu-py-310-base

--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -8,8 +8,8 @@
     "gov_aws_base_image": "ami-0cbd5dbd94f397bdd",
     "gcp_base_image": "ubuntu-2004-focal-v20220118",
     "image_description": "Determined environments",
-    "cpu_tf2_environment_name": "{{ env `DEFAULT_CPU_IMAGE` }}",
-    "gpu_tf2_environment_name": "{{ env `DEFAULT_CUDA_IMAGE` }}",
+    "cpu_tf2_environment_name": "{{ env `NGC_PYTORCH_REPO` }}",
+    "gpu_tf2_environment_name": "{{ env `NGC_PYTORCH_REPO` }}",
     "short_git_hash": "{{ env `short_git_hash` }}",
     "image_suffix": "",
     "docker_registry": "{{ env `DOCKERHUB_REGISTRY` }}"

--- a/cloud/environments-packer.json
+++ b/cloud/environments-packer.json
@@ -8,8 +8,8 @@
     "gov_aws_base_image": "ami-0cbd5dbd94f397bdd",
     "gcp_base_image": "ubuntu-2004-focal-v20220118",
     "image_description": "Determined environments",
-    "cpu_tf2_environment_name": "{{ env `CPU_TF_ENVIRONMENT_NAME` }}",
-    "gpu_tf2_environment_name": "{{ env `CUDA_TF_ENVIRONMENT_NAME` }}",
+    "cpu_tf2_environment_name": "{{ env `DEFAULT_CPU_IMAGE` }}",
+    "gpu_tf2_environment_name": "{{ env `DEFAULT_CUDA_IMAGE` }}",
     "short_git_hash": "{{ env `short_git_hash` }}",
     "image_suffix": "",
     "docker_registry": "{{ env `DOCKERHUB_REGISTRY` }}"


### PR DESCRIPTION
## Description

Set the images that are baked in to our AMIs and GCloud images to the shiny new NGC+ images.


## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] Test the images by running the test `bumpenvs` procedure in the determined repo. See [README](https://github.com/determined-ai/environments/blob/main/README.md).


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
