### PR TITLE
feat: fix install for efs-utils

### DIFF
--- a/cloud/roles/aws-fs/tasks/main.yml
+++ b/cloud/roles/aws-fs/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Build and install AWS EFS utilities.
   become: yes
   shell: |
-    sudo apt-get update
-    sudo apt-get -y install git binutils rustc cargo pkg-config libssl-dev
+    apt-get update
+    apt-get -y install git binutils rustc cargo pkg-config libssl-dev
     git clone https://github.com/aws/efs-utils
     cd efs-utils
     ./build-deb.sh

--- a/cloud/roles/aws-fs/tasks/main.yml
+++ b/cloud/roles/aws-fs/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: Build and install AWS EFS utilities.
   become: yes
   shell: |
+    sudo apt-get update
+    sudo apt-get -y install git binutils rustc cargo pkg-config libssl-dev
     git clone https://github.com/aws/efs-utils
     cd efs-utils
     ./build-deb.sh


### PR DESCRIPTION
## Description

MD-396
`efs-utils` was bumped from v1.36 to v2.0 which broke our install. This PR updates our install to match their [README](https://github.com/aws/efs-utils?tab=readme-ov-file#on-other-linux-distributions).

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] Test the images by running the test `bumpenvs` procedure in the determined repo. See [README](https://github.com/determined-ai/environments/blob/main/README.md).
