### PR TITLE
fix: numpy 2.x breaks tensorflow [MD-470]

### DIFF
--- a/Dockerfile-default-cpu
+++ b/Dockerfile-default-cpu
@@ -45,5 +45,7 @@ RUN pip install cmake==3.22.4 protobuf==3.20.3
 RUN pip install "$HOROVOD_PIP"
 
 RUN pip install -r /tmp/det_dockerfile_scripts/additional-requirements.txt
+# numpy 2.x breaks tensorflow. Using NGC recommended version.
+RUN pip install numpy==1.24.4
 
 RUN rm -r /tmp/*

--- a/Dockerfile-default-cuda
+++ b/Dockerfile-default-cuda
@@ -73,6 +73,8 @@ RUN if [ -n "${HOROVOD_PIP}" ]; then ldconfig /usr/local/cuda/targets/x86_64-lin
     ldconfig; fi
 
 RUN python -m pip install -r /tmp/det_dockerfile_scripts/additional-requirements.txt
+# numpy 2.x breaks tensorflow. Using NGC recommended version.
+RUN pip install numpy==1.24.4
 
 ARG DEEPSPEED_PIP
 RUN if [ -n "$DEEPSPEED_PIP" ]; then /tmp/det_dockerfile_scripts/install_deepspeed.sh; fi


### PR DESCRIPTION
## Description
Tensorflow needs numpy 1.x.

## Checklist

- [ ] Bump VERSION to make the pushed images are tagged with the right version.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
- [ ] Test the images by running the test `bumpenvs` procedure in the determined repo. See [README](https://github.com/determined-ai/environments/blob/main/README.md).


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
